### PR TITLE
Add apprise as a notification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker-compose up -d
 - **Multi-session**: Manage multiple MAM accounts in one instance
 - **Automation**: Auto-purchase wedges, VIP, upload credit with smart triggers
 - **Millionaire's Vault**: Advanced browser-cookie-based vault donation automation
-- **Notifications**: Email, webhook, Discord integration with event filtering
+- **Notifications**: Email (SMTP), Webhook (incl. Discord), and Apprise with event filtering
 - **Proxy support**: Global proxy management with testing and IP detection
 - **Port monitoring**: Monitor container ports, auto-restart with stack support
 - **IP monitoring modes**: Flexible IP monitoring for different network setups
@@ -90,7 +90,7 @@ MouseTrap offers three IP monitoring modes to suit different use cases and netwo
 | `IPDATA_API_KEY`| ipdata.co API key (optional)             | test    | 1,500 requests/day free   |
 | `LOGLEVEL`      | Backend log level                        | INFO    | DEBUG, INFO, WARNING      |
 
-> **Note:** For port monitoring, add `-/var/run/docker.sock:/var/run/docker.sock:ro` to volumes
+> **Note:** For port monitoring, add `- /var/run/docker.sock:/var/run/docker.sock:ro` to volumes
 
 ---
 
@@ -287,7 +287,7 @@ MouseTrap supports global proxy management and instant proxy testing:
 - Each check can be configured with its own interval (minimum 1 minute). Status is color-coded (green/yellow/red) based on reachability and last check time.
 - If Docker permissions are missing, the UI shows a warning, but the rest of the app remains fully functional.
 - All port check actions and container restarts are logged in the UI event log and filterable by label.
-- To support "compose stacks" (multiple services in a single Docker Compose script), you can monitor a primary container (e.g. VPN) and define secondary containers. MouseTrap will restart the primvary container and monitor for stability, then it will restart all secondary containers. This allows us to use the Docker Socket to restart an entire group of containers that might be dependent on the primary to restore network connection and stability to the system.
+- To support "compose stacks" (multiple services in a single Docker Compose script), you can monitor a primary container (e.g. VPN) and define secondary containers. MouseTrap will restart the primary container and monitor for stability, then it will restart all secondary containers. This allows us to use the Docker Socket to restart an entire group of containers that might be dependent on the primary to restore network connection and stability to the system.
 
 ---
 
@@ -318,10 +318,10 @@ services:
     container_name: mousetrap
     network_mode: "service:gluetun"
     environment:
-  - TZ=Europe/London
-  - PUID=1000
-  - PGID=1000
-  - DOCKER_GID=281 # (Optional) Set to your host's Docker group GID if not 992
+      - TZ=Europe/London
+      - PUID=1000
+      - PGID=1000
+      - DOCKER_GID=281 # (Optional) Set to your host's Docker group GID if not 992
     volumes:
       - ./config:/config
       - ./logs:/app/logs
@@ -361,10 +361,10 @@ services:
     image: ghcr.io/sirjmann92/mousetrap:latest
     container_name: mousetrap
     environment:
-  - TZ=Europe/London
-  - PUID=1000
-  - PGID=1000
-  - DOCKER_GID=281 # (Optional) Set to your host's Docker group GID if not 992
+      - TZ=Europe/London
+      - PUID=1000
+      - PGID=1000
+      - DOCKER_GID=281 # (Optional) Set to your host's Docker group GID if not 992
     volumes:
       - ./config:/config
       - ./logs:/app/logs 
@@ -416,7 +416,7 @@ Adjust paths and environment variables as needed for your Unraid setup.
 
 ## 🔔 Notifications
 
-MouseTrap supports notifications via Email (SMTP) and Webhook (including Discord). Configure these in the Notifications card in the UI.
+MouseTrap supports notifications via Email (SMTP), Webhook (including Discord), and Apprise. Configure and test these in the Notifications card in the UI.
 
 ### Email (SMTP)
 
@@ -431,7 +431,15 @@ MouseTrap supports notifications via Email (SMTP) and Webhook (including Discord
 ### Webhook
 
 - Enter your webhook URL in the UI. For Discord, check the "Discord" box to send Discord-compatible messages.
-- You can test both Email and Webhook notifications directly from the UI.
+
+
+### Apprise
+
+- Send notifications via an Apprise installation to any number of notification services.
+- In the UI, set:
+  - Apprise URL: e.g., `http://apprise:8000` (base URL only; do not include `/notify`)
+  - Notify URL String: e.g., `tgram://<bot-token>/<chat-id>` (see Apprise docs for providers)
+- See [Apprise documentation](https://github.com/caronc/apprise) for setup and building the notify URL string.
 
 ---
 

--- a/backend/api_notifications.py
+++ b/backend/api_notifications.py
@@ -1,49 +1,83 @@
-import os
 import yaml
-from fastapi import APIRouter, HTTPException, Request
-from backend.notifications_backend import send_webhook_notification, send_smtp_notification, NOTIFY_CONFIG_PATH
+from fastapi import APIRouter, HTTPException
+
+from backend.notifications_backend import (
+    NOTIFY_CONFIG_PATH,
+    load_notify_config,
+    send_apprise_notification,
+    send_smtp_notification,
+    send_webhook_notification,
+)
 
 router = APIRouter()
 
-# Load notification config
-def load_notify_config():
-    if not os.path.exists(NOTIFY_CONFIG_PATH):
-        return {}
-    with open(NOTIFY_CONFIG_PATH, 'r') as f:
-        return yaml.safe_load(f) or {}
 
 def save_notify_config(cfg):
-    with open(NOTIFY_CONFIG_PATH, 'w') as f:
+    with open(NOTIFY_CONFIG_PATH, "w") as f:
         yaml.safe_dump(cfg, f)
+
 
 @router.get("/notify/config")
 def get_notify_config():
     return load_notify_config()
+
 
 @router.post("/notify/config")
 def set_notify_config(cfg: dict):
     save_notify_config(cfg)
     return {"success": True}
 
+
 @router.post("/notify/test/webhook")
 def test_webhook(payload: dict):
     cfg = load_notify_config()
-    url = cfg.get('webhook_url')
-    discord_webhook = cfg.get('discord_webhook', False)
+    url = cfg.get("webhook_url")
+    discord_webhook = cfg.get("discord_webhook", False)
     if not url:
         raise HTTPException(status_code=400, detail="Webhook URL not set.")
     ok = send_webhook_notification(url, payload, discord=discord_webhook)
     return {"success": ok}
 
+
 @router.post("/notify/test/smtp")
 def test_smtp(payload: dict):
     cfg = load_notify_config()
-    smtp = cfg.get('smtp', {})
-    required = ['host', 'port', 'username', 'password', 'to_email']
+    smtp = cfg.get("smtp", {})
+    required = ["host", "port", "username", "password", "to_email"]
     if not all(k in smtp for k in required):
         raise HTTPException(status_code=400, detail="SMTP config incomplete.")
     ok = send_smtp_notification(
-        smtp['host'], smtp['port'], smtp['username'], smtp['password'],
-        smtp['to_email'], payload.get('subject', 'Test'), payload.get('body', 'Test'), smtp.get('use_tls', True)
+        smtp["host"],
+        smtp["port"],
+        smtp["username"],
+        smtp["password"],
+        smtp["to_email"],
+        payload.get("subject", "Test"),
+        payload.get("body", "Test"),
+        smtp.get("use_tls", True),
     )
+    return {"success": ok}
+
+
+@router.post("/notify/test/apprise")
+def test_apprise(payload: dict):
+    cfg = load_notify_config()
+    apprise_cfg = cfg.get("apprise", {})
+    apprise_url = apprise_cfg.get("url")
+    notify_url_string = apprise_cfg.get("notify_url_string")
+    include_prefix = apprise_cfg.get("include_prefix", False)
+    if not apprise_url or not notify_url_string:
+        raise HTTPException(status_code=400, detail="Apprise config incomplete.")
+
+    test_payload = {
+        "event_type": payload.get("event_type", "test"),
+        "label": payload.get("label", "UI Test"),
+        "status": payload.get("status", "TEST"),
+        "message": payload.get(
+            "message", "Session: UI Test, Test Apprise notification from MouseTrap"
+        ),
+        "details": payload.get("details", {}),
+    }
+
+    ok = send_apprise_notification(apprise_url, notify_url_string, test_payload, include_prefix)
     return {"success": ok}

--- a/backend/notifications_backend.py
+++ b/backend/notifications_backend.py
@@ -1,14 +1,16 @@
+import logging
 import os
 import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Dict, Optional
+
 import requests
 import yaml
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
-from typing import Optional, Dict
-import logging
 
 # Notification config (could be loaded from YAML or env)
-NOTIFY_CONFIG_PATH = os.environ.get('NOTIFY_CONFIG_PATH', '/config/notify.yaml')
+NOTIFY_CONFIG_PATH = os.environ.get("NOTIFY_CONFIG_PATH", "/config/notify.yaml")
+
 
 def send_webhook_notification(url: str, payload: dict, discord: bool = False) -> bool:
     try:
@@ -24,6 +26,7 @@ def send_webhook_notification(url: str, payload: dict, discord: bool = False) ->
         logging.error(f"[Notify] Webhook failed: {e}")
         return False
 
+
 def send_smtp_notification(
     smtp_host: str,
     smtp_port: int,
@@ -32,14 +35,14 @@ def send_smtp_notification(
     to_email: str,
     subject: str,
     body: str,
-    use_tls: bool = True
+    use_tls: bool = True,
 ) -> bool:
     try:
         msg = MIMEMultipart()
-        msg['From'] = username
-        msg['To'] = to_email
-        msg['Subject'] = subject
-        msg.attach(MIMEText(body, 'plain'))
+        msg["From"] = username
+        msg["To"] = to_email
+        msg["Subject"] = subject
+        msg.attach(MIMEText(body, "plain"))
         server = smtplib.SMTP(smtp_host, smtp_port, timeout=10)
         if use_tls:
             server.starttls()
@@ -52,13 +55,86 @@ def send_smtp_notification(
         return False
 
 
+def send_apprise_notification(
+    apprise_url: str, notify_url_string: str, payload: dict, include_prefix: bool = False
+) -> bool:
+    """Send a notification using Apprise.
+
+    Returns True on success, False on failure.
+    """
+
+    if not notify_url_string or not apprise_url:
+        logging.error("[Notify] Apprise config missing apprise_url or notify_url_string")
+        return False
+
+    event_type = payload.get("event_type", "Notification").replace("_", " ").title()
+    status = (": " + payload.get("status", "").title()) if payload.get("status") else ""
+    title_prefix = "MouseTrap: " if include_prefix else ""
+    title = f"{title_prefix}{event_type}{status}"
+    message = payload.get("message", "")
+    notif_type = (
+        "success"
+        if payload.get("status") == "SUCCESS"
+        else "failure"
+        if payload.get("status") == "FAILED"
+        else "info"
+    )
+
+    try:
+        apprise_base = apprise_url.rstrip("/")
+        if apprise_base.lower().endswith("/notify"):
+            post_url = apprise_base
+        else:
+            post_url = f"{apprise_base}/notify"
+
+        response: requests.Response = requests.post(
+            post_url,
+            data={"urls": notify_url_string, "body": message, "title": title, "type": notif_type},
+            timeout=5,
+        )
+
+        if not response.ok:
+            logging.error(
+                "[Notify] Apprise failed. Response: %s - %s",
+                response.status_code,
+                response.text,
+            )
+            return False
+
+        # Try to parse JSON; if JSON is present and explicitly indicates failure,
+        # treat that as a failure. If JSON can't be parsed, fall back to treating
+        # the 200 as success.
+        try:
+            resp_json = response.json()
+        except ValueError:
+            resp_json = None
+
+        if isinstance(resp_json, dict) and resp_json.get("success") is False:
+            logging.error("[Notify] Apprise failed. success=false: %s", resp_json)
+            return False
+
+    except requests.RequestException as e:
+        logging.error("[Notify] Apprise failed. %s: %s", type(e).__name__, e)
+        return False
+    else:
+        logging.info("[Notify] Apprise sent successfully")
+        return True
+
+
 def load_notify_config():
     if not os.path.exists(NOTIFY_CONFIG_PATH):
         return {}
-    with open(NOTIFY_CONFIG_PATH, 'r') as f:
+    with open(NOTIFY_CONFIG_PATH, "r") as f:
         return yaml.safe_load(f) or {}
 
-def notify_event(event_type: str, label: Optional[str] = None, status: Optional[str] = None, message: Optional[str] = None, details: Optional[Dict] = None):
+
+def notify_event(
+    event_type: str,
+    label: Optional[str] = None,
+    status: Optional[str] = None,
+    message: Optional[str] = None,
+    details: Optional[Dict] = None,
+):
     """
     Send notification (webhook and/or SMTP) for important events.
     event_type: e.g. 'port_monitor_failure', 'automation_success', 'automation_failure'
@@ -68,35 +144,55 @@ def notify_event(event_type: str, label: Optional[str] = None, status: Optional[
     details: dict of extra info
     """
     cfg = load_notify_config()
-    event_rules = cfg.get('event_rules', {})
-    rule = event_rules.get(event_type, {"email": False, "webhook": False})
+    event_rules = cfg.get("event_rules", {})
+    rule = event_rules.get(event_type, {"email": False, "webhook": False, "apprise": False})
     # Prevent spam: only send if at least one channel is enabled for this event
-    if not rule.get("email") and not rule.get("webhook"):
+    if not rule.get("email") and not rule.get("webhook") and not rule.get("apprise"):
         return
     # Always prepend session name to the message if label is present
     session_prefix = f"Session: {label}, " if label else ""
-    full_message = f"{session_prefix}{message}" if message else session_prefix.rstrip(', ')
+    full_message = f"{session_prefix}{message}" if message else session_prefix.rstrip(", ")
     payload = {
         "event_type": event_type,
         "label": label,
         "status": status,
         "message": full_message,
-        "details": details or {}
+        "details": details or {},
     }
     # Webhook
     if rule.get("webhook"):
-        webhook_url = cfg.get('webhook_url')
-        discord_webhook = cfg.get('discord_webhook', False)
+        webhook_url = cfg.get("webhook_url")
+        discord_webhook = cfg.get("discord_webhook", False)
         if webhook_url:
             send_webhook_notification(webhook_url, payload, discord=discord_webhook)
     # SMTP
     if rule.get("email"):
-        smtp = cfg.get('smtp', {})
-        required = ['host', 'port', 'username', 'password', 'to_email']
+        smtp = cfg.get("smtp", {})
+        required = ["host", "port", "username", "password", "to_email"]
         if all(k in smtp for k in required):
             subject = f"[MouseTrap] {event_type} - {status or ''}"
             body = f"Event: {event_type}\nLabel: {label}\nStatus: {status}\nMessage: {full_message}\nDetails: {details}"
             send_smtp_notification(
-                smtp['host'], smtp['port'], smtp['username'], smtp['password'],
-                smtp['to_email'], subject, body, smtp.get('use_tls', True)
+                smtp["host"],
+                smtp["port"],
+                smtp["username"],
+                smtp["password"],
+                smtp["to_email"],
+                subject,
+                body,
+                smtp.get("use_tls", True),
+            )
+
+    # Apprise
+    if rule.get("apprise"):
+        apprise_cfg = cfg.get("apprise", {})
+        apprise_url = apprise_cfg.get("url")
+        notify_url_string = apprise_cfg.get("notify_url_string")
+        include_prefix = apprise_cfg.get("include_prefix", False)
+        if apprise_url and notify_url_string:
+            send_apprise_notification(
+                apprise_url=apprise_url,
+                notify_url_string=notify_url_string,
+                payload=payload,
+                include_prefix=include_prefix,
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apprise as a notification channel: UI fields for URL, notify string, include-prefix, per-event Apprise toggle, gating, and a Test Apprise button; backend supports Apprise delivery and a Test Apprise API.

* **Bug Fixes**
  * Improved webhook handling (Discord payloads), more robust SMTP delivery and error logging, and config loading now merges into existing settings.

* **Documentation**
  * Docs updated with Apprise setup, examples, testing guidance, and minor typo/formatting fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->