### PR TITLE
Add cross-layer integration and E2E test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,242 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            requirements.txt
+
+      - name: Install backend test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            -r requirements.txt \
+            httpx \
+            pytest \
+            pytest-asyncio \
+            pytest-cov \
+            pytest-timeout
+
+      - name: Run all backend tests
+        run: |
+          set -o pipefail
+          npm run test:backend:all -- --junitxml=junit.xml \
+            2>&1 | tee backend-tests.log
+
+      - name: Upload backend failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: backend-test-diagnostics
+          path: |
+            backend-tests.log
+            junit.xml
+            htmlcov/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  playwright:
+    name: Development Playwright tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            requirements.txt
+
+      - name: Install backend runtime dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Set up Node.js 22.20
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.20.0"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run development end-to-end tests
+        run: |
+          set -o pipefail
+          npm run test:e2e 2>&1 | tee playwright-dev.log
+
+      - name: Upload Playwright failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-dev-diagnostics
+          path: |
+            playwright-dev.log
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  container:
+    name: Docker container smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      E2E_CONTAINER_NAME: mousetrap-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+      E2E_IMAGE_NAME: mousetrap-e2e:${{ github.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js 22.20
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.20.0"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Build test image
+        run: docker build --tag "$E2E_IMAGE_NAME" .
+
+      - name: Start test container
+        run: |
+          E2E_CONFIG_DIR="$RUNNER_TEMP/mousetrap-e2e-config"
+          mkdir -p "$E2E_CONFIG_DIR"
+          chmod 0777 "$E2E_CONFIG_DIR"
+          docker run --detach \
+            --name "$E2E_CONTAINER_NAME" \
+            --publish 127.0.0.1:39842:39842 \
+            --volume "$E2E_CONFIG_DIR:/config" \
+            "$E2E_IMAGE_NAME"
+
+      - name: Wait for container health
+        run: |
+          for _ in $(seq 1 60); do
+            if curl --fail --silent --show-error \
+              http://127.0.0.1:39842/api/version > /dev/null; then
+              exit 0
+            fi
+            if ! docker inspect \
+              --format '{{.State.Running}}' "$E2E_CONTAINER_NAME" \
+              | grep -qx true; then
+              docker logs "$E2E_CONTAINER_NAME"
+              exit 1
+            fi
+            sleep 2
+          done
+          docker logs "$E2E_CONTAINER_NAME"
+          exit 1
+
+      - name: Verify session persistence and restart container
+        run: |
+          curl --fail --silent --show-error \
+            --header 'Content-Type: application/json' \
+            --data '{"label":"container-smoke"}' \
+            http://127.0.0.1:39842/api/session/save
+          curl --fail --silent --show-error \
+            http://127.0.0.1:39842/api/session/container-smoke
+          test -s "$RUNNER_TEMP/mousetrap-e2e-config/session-container-smoke.yaml"
+          curl --fail --silent --show-error \
+            --request DELETE \
+            http://127.0.0.1:39842/api/session/delete/container-smoke
+          curl --fail --silent --show-error \
+            --header 'Content-Type: application/json' \
+            --data '{"label":"container-smoke-proxy","host":"127.0.0.1","port":8080}' \
+            http://127.0.0.1:39842/api/proxies
+          docker restart "$E2E_CONTAINER_NAME"
+          for _ in $(seq 1 60); do
+            if curl --fail --silent --show-error \
+              http://127.0.0.1:39842/api/version > /dev/null; then
+              exit 0
+            fi
+            if ! docker inspect \
+              --format '{{.State.Running}}' "$E2E_CONTAINER_NAME" \
+              | grep -qx true; then
+              docker logs "$E2E_CONTAINER_NAME"
+              exit 1
+            fi
+            sleep 2
+          done
+          docker logs "$E2E_CONTAINER_NAME"
+          exit 1
+
+      - name: Run container smoke tests
+        env:
+          E2E_BASE_URL: http://127.0.0.1:39842
+        run: |
+          set -o pipefail
+          npm run test:e2e:container 2>&1 | tee playwright-container.log
+
+      - name: Collect container diagnostics
+        if: failure()
+        run: |
+          mkdir -p container-diagnostics
+          docker ps -a \
+            --filter "name=^/${E2E_CONTAINER_NAME}$" \
+            > container-diagnostics/docker-ps.txt
+          docker inspect "$E2E_CONTAINER_NAME" \
+            > container-diagnostics/container-inspect.json || true
+          docker logs "$E2E_CONTAINER_NAME" \
+            > container-diagnostics/container.log 2>&1 || true
+
+      - name: Upload container failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: container-smoke-diagnostics
+          path: |
+            playwright-container.log
+            container-diagnostics/
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Clean up test containers
+        if: always()
+        run: |
+          docker rm --force "$E2E_CONTAINER_NAME" 2>/dev/null || true
+          docker image rm "$E2E_IMAGE_NAME" 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ pythonenv*
 pyvenv.cfg
 scripts/
 session-*.yaml*
-tests/
 Thumbs.db
 venv.bak/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ env/
 favicon_io/
 frontend/.cache/
 frontend/node_modules/
+frontend/playwright-report/
+frontend/test-results/
 htmlcov/
 junit.xml
 last_session.yaml*

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ proxies.yaml*
 pytest.xml
 pythonenv*
 pyvenv.cfg
-scripts/
 session-*.yaml*
 Thumbs.db
 venv.bak/

--- a/README.md
+++ b/README.md
@@ -277,6 +277,30 @@ cd mousetrap
 docker compose up --build -d
 ```
 
+### Run the Test Suites
+
+Backend integration and workflow tests use the repository virtual environment:
+
+```bash
+./.venv/bin/python -m pytest
+./.venv/bin/python -m pytest -m integration
+./.venv/bin/python -m pytest -m workflow
+```
+
+Browser tests start isolated Vite and FastAPI development servers and use a temporary
+configuration directory:
+
+```bash
+cd frontend
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+The `test:e2e:container` command runs the production-image smoke scenarios against the
+URL supplied in `E2E_BASE_URL`. The GitHub Actions test workflow builds, seeds, restarts,
+and cleans up that container automatically.
+
 ---
 
 ## 🌐 VPN Integration

--- a/README.md
+++ b/README.md
@@ -279,23 +279,26 @@ docker compose up --build -d
 
 ### Run the Test Suites
 
-Backend integration and workflow tests use the repository virtual environment:
+Install the backend development requirements and frontend browser dependencies
+once:
 
 ```bash
-./.venv/bin/python -m pytest
-./.venv/bin/python -m pytest -m integration
-./.venv/bin/python -m pytest -m workflow
-```
-
-Browser tests start isolated Vite and FastAPI development servers and use a temporary
-configuration directory:
-
-```bash
+./.venv/bin/python -m pip install -r requirements-dev.txt
 cd frontend
 npm ci
 npx playwright install chromium
-npm run test:e2e
+cd ..
 ```
+
+Then run the complete backend and frontend test gate with one command:
+
+```bash
+./scripts/run-tests.sh
+```
+
+The script runs the full pytest suite, then starts isolated Vite and FastAPI
+development servers for the Playwright suite using a temporary configuration
+directory.
 
 The `test:e2e:container` command runs the production-image smoke scenarios against the
 URL supplied in `E2E_BASE_URL`. The GitHub Actions test workflow builds, seeds, restarts,

--- a/backend/api_notifications.py
+++ b/backend/api_notifications.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-import yaml
 
 from backend.notifications_backend import (
     NOTIFY_CONFIG_PATH,
@@ -21,6 +20,7 @@ from backend.notifications_backend import (
     send_smtp_notification,
     send_webhook_notification,
 )
+from backend.yaml_store import write_yaml_file
 
 router = APIRouter()
 
@@ -33,9 +33,7 @@ def save_notify_config(cfg: dict[str, Any]) -> None:
 
     """
     path = Path(NOTIFY_CONFIG_PATH)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+    write_yaml_file(path, cfg)
 
 
 @router.get("/notify/config")

--- a/backend/api_port_monitor.py
+++ b/backend/api_port_monitor.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 
 from backend.event_log import append_ui_event_log
 from backend.port_monitor import port_monitor_manager
+from backend.yaml_store import YamlStoreError
 
 _logger: logging.Logger = logging.getLogger(__name__)
 _CONTAINER_WARN_INTERVAL = 60
@@ -90,13 +91,19 @@ def update_stack(
         "primary_port": stack.primary_port,
         "secondary_containers": stack.secondary_containers,
         "interval": stack.interval,
+        "public_ip": stack.public_ip,
     }
     stack.primary_container = req.primary_container
     stack.primary_port = req.primary_port
     stack.secondary_containers = req.secondary_containers
     stack.interval = req.interval
     stack.public_ip = req.public_ip
-    port_monitor_manager.save_stacks()
+    try:
+        port_monitor_manager.save_stacks()
+    except YamlStoreError:
+        for field, value in old_values.items():
+            setattr(stack, field, value)
+        raise
     # Immediately recheck status after edit
     port_monitor_manager.recheck_stack(name)
     if changed:
@@ -258,9 +265,8 @@ def restart_stack(name: str = Query(..., description="Stack name")) -> dict[str,
     stack = port_monitor_manager.get_stack(name)
     if not stack:
         raise HTTPException(status_code=404, detail="Stack not found")
-    # Set status to 'Restarting' and save immediately
+    # Set runtime status immediately; status is not part of persisted configuration.
     stack.status = "Restarting"
-    port_monitor_manager.save_stacks()
     _logger.info("[PortMonitorStackAPI] Stack '%s' status set to 'Restarting'", name)
     append_ui_event_log(
         {
@@ -300,7 +306,6 @@ def restart_stack(name: str = Query(..., description="Stack name")) -> dict[str,
                 "level": "info",
             }
         )
-        port_monitor_manager.recheck_stack(stack.name)
         _logger.info("[PortMonitorStackAPI] Status recheck complete for stack '%s'", name)
         append_ui_event_log(
             {

--- a/backend/api_proxy.py
+++ b/backend/api_proxy.py
@@ -6,6 +6,7 @@ public IP and ASN. It also ensures sessions referencing deleted proxies are
 cleaned up.
 """
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
@@ -13,8 +14,10 @@ from fastapi import APIRouter, HTTPException
 from backend.config import list_sessions, load_session, save_session
 from backend.ip_lookup import get_asn_and_timezone_from_ip, get_ipinfo_with_fallback, get_public_ip
 from backend.proxy_config import load_proxies, save_proxies
+from backend.yaml_store import YamlStoreError
 
 router = APIRouter()
+_logger: logging.Logger = logging.getLogger(__name__)
 
 
 @router.get("/proxy_test/{label}")
@@ -77,7 +80,15 @@ def delete_proxy(label: str) -> dict[str, Any]:
 
     sessions = list_sessions()
     for sess_label in sessions:
-        cfg = load_session(sess_label)
+        try:
+            cfg = load_session(sess_label)
+        except YamlStoreError as err:
+            _logger.warning(
+                "Skipping proxy cleanup for corrupt session '%s': %s",
+                sess_label,
+                err,
+            )
+            continue
         proxy_cfg = cfg.get("proxy", {})
         if isinstance(proxy_cfg, dict) and proxy_cfg.get("label") == label:
             cfg["proxy"] = {}  # Remove proxy reference

--- a/backend/app.py
+++ b/backend/app.py
@@ -67,6 +67,7 @@ from backend.prowlarr_integration import (
 )
 from backend.proxy_config import resolve_proxy_from_session_cfg
 from backend.utils import build_proxy_dict, build_status_message, extract_asn_number, setup_logging
+from backend.yaml_store import YamlStoreError
 
 BASE_DIR = Path(__file__).resolve().parent
 FRONTEND_BUILD_DIR = (Path(BASE_DIR) / "../frontend/build").resolve()
@@ -1033,7 +1034,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
     mam_seen_asn = str(mam_seen.get("ASN")) if mam_seen.get("ASN") is not None else None
     mam_seen_as = mam_seen.get("AS")
     tz_env = os.environ.get("TZ")
-    timezone_used = tz_env if tz_env else "UTC"
+    timezone_used = tz_env or "UTC"
     now = datetime.now(UTC)
     # Remove timer persistence: do not use session file for last_check_time
     cache = session_status_cache.get(label, {})
@@ -1613,23 +1614,31 @@ async def api_save_session(request: Request) -> dict[str, Any]:
     """
     global session_status_cache
 
+    saved = False
     try:
         cfg = await request.json()
         old_label = cfg.get("old_label")
         proxy_cfg = cfg.get("proxy", {}) or {}
         prev_cfg = None
 
+        def load_previous_config(label: str) -> dict[str, Any] | None:
+            """Load prior state, allowing valid UI data to replace corrupt YAML."""
+            try:
+                return load_session(label)
+            except YamlStoreError as err:
+                _logger.warning(
+                    "[Session] Could not load existing session '%s'; "
+                    "saving without preserved fields: %s",
+                    label,
+                    err,
+                )
+                return None
+
         if "proxy" in cfg:
             if old_label:
-                try:
-                    prev_cfg = load_session(old_label)
-                except Exception:
-                    prev_cfg = None
+                prev_cfg = load_previous_config(old_label)
             elif cfg.get("label"):
-                try:
-                    prev_cfg = load_session(cfg["label"])
-                except Exception:
-                    prev_cfg = None
+                prev_cfg = load_previous_config(cfg["label"])
             # If password is missing but previous session had one, keep it
             if (
                 isinstance(proxy_cfg, dict)
@@ -1661,15 +1670,9 @@ async def api_save_session(request: Request) -> dict[str, Any]:
         # If prev_cfg not set above, try to load it now
         if prev_cfg is None:
             if old_label:
-                try:
-                    prev_cfg = load_session(old_label)
-                except Exception:
-                    prev_cfg = None
+                prev_cfg = load_previous_config(old_label)
             elif cfg.get("label"):
-                try:
-                    prev_cfg = load_session(cfg["label"])
-                except Exception:
-                    prev_cfg = None
+                prev_cfg = load_previous_config(cfg["label"])
         if prev_cfg:
             for field in backend_fields:
                 if field in prev_cfg and field not in cfg:
@@ -1679,12 +1682,13 @@ async def api_save_session(request: Request) -> dict[str, Any]:
         session_path = get_session_path(label)
         is_new = not Path(session_path).exists()
 
+        save_session(cfg, old_label=old_label)
+        saved = True
+
         if is_new:
             # Clear any old event log entries for this session label
-
             clear_ui_event_log_for_session(label)
             # Only log creation event
-            save_session(cfg, old_label=old_label)
             _logger.info("[Session] Created session: label=%s", label)
             append_ui_event_log(
                 {
@@ -1701,7 +1705,6 @@ async def api_save_session(request: Request) -> dict[str, Any]:
                 session_status_cache[label]["suppress_next_event"] = True
         else:
             # Only log save event (update)
-            save_session(cfg, old_label=old_label)
             _logger.info("[Session] Saved session: label=%s old_label=%s", label, old_label)
             append_ui_event_log(
                 {
@@ -1736,6 +1739,13 @@ async def api_save_session(request: Request) -> dict[str, Any]:
         await _sync_integrations_if_mam_id_changed(cfg, label, new_mam_id, prev_mam_id)
 
     except Exception as e:
+        if saved:
+            _logger.exception(
+                "[Session] Post-save side effect failed for label=%s; "
+                "session persistence already completed",
+                cfg.get("label"),
+            )
+            return {"success": True}
         raise HTTPException(status_code=500, detail=f"Failed to save session: {e}") from e
     else:
         return {"success": True}
@@ -3121,7 +3131,14 @@ def register_all_session_jobs() -> None:
     """
     session_labels = list_sessions()
     for label in session_labels:
-        register_session_job(label)
+        try:
+            register_session_job(label)
+        except YamlStoreError as err:
+            _logger.error(
+                "[APScheduler] Failed to load session '%s'; skipping job registration: %s",
+                label,
+                err,
+            )
 
 
 # Immediate session check for all sessions at startup

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,14 +7,12 @@ the backend to locate and manage session files.
 
 from os import environ
 from pathlib import Path
-import threading
 from typing import Any
 
-import yaml
+from backend.yaml_store import YamlStoreError, load_yaml_file, write_yaml_file
 
 CONFIG_DIR = Path(environ.get("CONFIG_DIR", "/config"))
 CONFIG_PATH = CONFIG_DIR / "config.yaml"
-_LOCK = threading.Lock()
 
 
 SESSION_PREFIX = "session-"
@@ -34,7 +32,7 @@ def list_sessions() -> list[str]:
     """Return a list of session labels present in the config directory.
 
     Scans the ``CONFIG_DIR`` for files that match the session naming
-    convention and returns the extracted labels (without prefix/suffix).
+    convention and returns the extracted labels.
     """
     files = list(CONFIG_DIR.glob(f"{SESSION_PREFIX}*{SESSION_SUFFIX}"))
     return [f.name[len(SESSION_PREFIX) : -len(SESSION_SUFFIX)] for f in files]
@@ -59,21 +57,23 @@ def decrypt_password(token: str) -> str:
     return token
 
 
+def _ensure_mapping(parent: dict[str, Any], key: str, section: str) -> dict[str, Any]:
+    """Return a mutable config section, rejecting persisted non-mappings."""
+    value = parent.setdefault(key, {})
+    if not isinstance(value, dict):
+        raise YamlStoreError(f"Session section '{section}' must be a mapping.")
+    return value
+
+
 def load_session(label: str) -> dict[str, Any]:
     """Load a session configuration by label.
 
-    If the session file does not exist the default config is returned. The
-    returned dictionary is guaranteed to contain keys expected by the
-    application (some defaults are populated if missing).
+    The returned dictionary contains the keys expected by the application.
     """
     path = get_session_path(label)
-    if not path.exists():
-        cfg = get_default_config(label)
-    else:
-        with _LOCK, path.open(encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or get_default_config(label)
+    cfg = load_yaml_file(path, get_default_config(label), expected_type=dict)
     # --- Ensure all perk automation configs are always present and complete ---
-    perk_auto = cfg.setdefault("perk_automation", {})
+    perk_auto = _ensure_mapping(cfg, "perk_automation", "perk_automation")
     # Upload Credit Automation defaults
     upload_defaults = {
         "enabled": False,
@@ -84,7 +84,11 @@ def load_session(label: str) -> dict[str, Any]:
         "trigger_days": 7,
         "trigger_point_threshold": 50000,
     }
-    upload_auto = perk_auto.setdefault("upload_credit", {})
+    upload_auto = _ensure_mapping(
+        perk_auto,
+        "upload_credit",
+        "perk_automation.upload_credit",
+    )
     for k, v in upload_defaults.items():
         upload_auto.setdefault(k, v)
 
@@ -95,7 +99,11 @@ def load_session(label: str) -> dict[str, Any]:
         "trigger_point_threshold": 50000,
         "trigger_type": "time",
     }
-    wedge_auto = perk_auto.setdefault("wedge_automation", {})
+    wedge_auto = _ensure_mapping(
+        perk_auto,
+        "wedge_automation",
+        "perk_automation.wedge_automation",
+    )
     for k, v in wedge_defaults.items():
         wedge_auto.setdefault(k, v)
 
@@ -107,15 +115,20 @@ def load_session(label: str) -> dict[str, Any]:
         "trigger_point_threshold": 50000,
         "weeks": 4,
     }
-    vip_auto = perk_auto.setdefault("vip_automation", {})
+    vip_auto = _ensure_mapping(
+        perk_auto,
+        "vip_automation",
+        "perk_automation.vip_automation",
+    )
     for k, v in vip_defaults.items():
         vip_auto.setdefault(k, v)
 
     if "mam_ip" not in cfg:
         cfg["mam_ip"] = ""
     # Backward compatibility for ip_monitoring_mode
-    if "ip_monitoring_mode" not in cfg.get("mam", {}):
-        cfg.setdefault("mam", {})["ip_monitoring_mode"] = "auto"
+    mam_cfg = _ensure_mapping(cfg, "mam", "mam")
+    if "ip_monitoring_mode" not in mam_cfg:
+        mam_cfg["ip_monitoring_mode"] = "auto"
     if "last_check_time" not in cfg:
         cfg["last_check_time"] = None
     if "label" not in cfg:
@@ -131,7 +144,7 @@ def load_session(label: str) -> dict[str, Any]:
         "api_key": "",
         "auto_update_on_save": False,
     }
-    prowlarr_cfg = cfg.setdefault("prowlarr", {})
+    prowlarr_cfg = _ensure_mapping(cfg, "prowlarr", "prowlarr")
     for k, v in prowlarr_defaults.items():
         prowlarr_cfg.setdefault(k, v)
 
@@ -146,29 +159,24 @@ def load_session(label: str) -> dict[str, Any]:
     return cfg
 
 
-def save_session(cfg: dict, old_label: str | None = None) -> None:
+def save_session(cfg: dict[str, Any], old_label: str | None = None) -> None:
     """Persist a session configuration to disk.
 
     If ``old_label`` is provided and different from the new label the
-    existing file will be renamed. The function ensures the containing
-    directory exists and writes the YAML representation of ``cfg``.
+    new file is written completely before the old file is removed. An old-file
+    unlink failure is propagated and may leave both complete files present.
     """
     label = cfg.get("label")
     if not label:
         raise ValueError("Session label is required to save a session.")
     path = get_session_path(label)
-    # If label changed, rename file
+    if "browser_cookie" not in cfg:
+        cfg["browser_cookie"] = ""
+    write_yaml_file(path, cfg)
     if old_label and old_label != label:
         old_path = get_session_path(old_label)
         if old_path.exists():
-            old_path.rename(path)
-    config_dir = path.parent
-    config_dir.mkdir(parents=True, exist_ok=True)
-    # No encryption: just save password as-is
-    if "browser_cookie" not in cfg:
-        cfg["browser_cookie"] = ""
-    with _LOCK, path.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+            old_path.unlink()
 
 
 def get_default_config(label: str | None = None) -> dict[str, Any]:
@@ -196,38 +204,27 @@ def get_default_config(label: str | None = None) -> dict[str, Any]:
 def load_config() -> dict[str, Any]:
     """Load the global default configuration from CONFIG_PATH.
 
-    If the config file does not exist returns a default config. Ensures a
-    few expected keys are present before returning.
+    If the config file does not exist, defaults are returned. Existing corrupt
+    or wrong-shaped YAML raises ``YamlStoreError``. Ensures a few expected keys
+    are present before returning.
     """
-    # Load default config.yaml for defaults only
-    if not CONFIG_PATH.exists():
-        return get_default_config()
-    with _LOCK, CONFIG_PATH.open(encoding="utf-8") as f:
-        cfg = yaml.safe_load(f) or get_default_config()
-        if "mam_ip" not in cfg:
-            cfg["mam_ip"] = ""
-        if "last_check_time" not in cfg:
-            cfg["last_check_time"] = None
-        if "label" not in cfg:
-            cfg["label"] = ""
-        return cfg
+    cfg = load_yaml_file(CONFIG_PATH, get_default_config(), expected_type=dict)
+    if "mam_ip" not in cfg:
+        cfg["mam_ip"] = ""
+    if "last_check_time" not in cfg:
+        cfg["last_check_time"] = None
+    if "label" not in cfg:
+        cfg["label"] = ""
+    return cfg
 
 
 def save_config(cfg: dict[str, Any]) -> None:
-    """Persist the given global configuration to CONFIG_PATH.
-
-    Ensures the config directory exists and writes the YAML file.
-    """
+    """Persist the given global configuration to CONFIG_PATH."""
     # Save to config.yaml (for defaults)
-    config_dir = CONFIG_PATH.parent
-    config_dir.mkdir(parents=True, exist_ok=True)
-    with _LOCK, CONFIG_PATH.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+    write_yaml_file(CONFIG_PATH, cfg)
 
 
 def delete_session(label: str) -> None:
-    """Delete the session file for a given label if it exists."""
-
+    """Delete the primary session file for a given label if it exists."""
     path = get_session_path(label)
-    if path.exists():
-        path.unlink()
+    path.unlink(missing_ok=True)

--- a/backend/last_session_api.py
+++ b/backend/last_session_api.py
@@ -10,9 +10,9 @@ Persistence is a simple YAML file located at `LAST_SESSION_FILE`.
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
-import yaml
 
 from backend.config import CONFIG_DIR
+from backend.yaml_store import load_yaml_file, write_yaml_file
 
 router = APIRouter()
 LAST_SESSION_FILE = CONFIG_DIR / "last_session.yaml"
@@ -22,13 +22,13 @@ def read_last_session() -> str | None:
     """Read the last session label from disk.
 
     Returns:
-        The saved label string, or None if the file does not exist or is malformed.
+        The saved label string, or None if the file does not exist.
+
+    Raises:
+        YamlStoreError: If the existing settings file is invalid.
     """
-    if not LAST_SESSION_FILE.exists():
-        return None
-    with LAST_SESSION_FILE.open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-        return data.get("label") if isinstance(data, dict) else None
+    data = load_yaml_file(LAST_SESSION_FILE, {}, expected_type=dict)
+    return data.get("label")
 
 
 def write_last_session(label: str | None) -> None:
@@ -37,9 +37,7 @@ def write_last_session(label: str | None) -> None:
     Args:
         label: The session label to persist.
     """
-    LAST_SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with LAST_SESSION_FILE.open("w", encoding="utf-8") as f:
-        yaml.safe_dump({"label": label if label else ""}, f)
+    write_yaml_file(LAST_SESSION_FILE, {"label": label or ""})
 
 
 @router.get("/last_session")

--- a/backend/notifications_backend.py
+++ b/backend/notifications_backend.py
@@ -15,9 +15,9 @@ import smtplib
 from typing import Any
 
 import aiohttp
-import yaml
 
 from backend.config import CONFIG_DIR
+from backend.yaml_store import load_yaml_file
 
 _logger: logging.Logger = logging.getLogger(__name__)
 # Notification config: explicit NOTIFY_CONFIG_PATH override, else derived from CONFIG_DIR
@@ -272,18 +272,15 @@ def load_notify_config() -> dict[str, Any]:
     """Load notification configuration from a YAML file.
 
     The path is taken from the NOTIFY_CONFIG_PATH environment variable or
-    a sensible default. Returns an empty dict when the file does not exist
-    or cannot be parsed.
+    a sensible default.
 
-    Returns
-    -------
-    dict
-        Parsed YAML as a dictionary, or an empty dict on failure.
+    Returns:
+        Parsed YAML as a dictionary, or an empty dict if the file is missing.
+
+    Raises:
+        YamlStoreError: If the existing file is invalid or not a mapping.
     """
-    if not Path(NOTIFY_CONFIG_PATH).exists():
-        return {}
-    with Path(NOTIFY_CONFIG_PATH).open(encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
+    return load_yaml_file(Path(NOTIFY_CONFIG_PATH), {}, expected_type=dict)
 
 
 async def notify_event(

--- a/backend/port_monitor.py
+++ b/backend/port_monitor.py
@@ -15,11 +15,10 @@ import threading
 import time
 from typing import Any
 
-import yaml
-
 from backend.config import CONFIG_DIR
 from backend.event_log import append_ui_event_log
-from backend.notifications_backend import notify_event
+from backend.notifications_backend import safe_notify_event
+from backend.yaml_store import YamlStoreError, load_yaml_file, write_yaml_file
 
 try:
     import docker
@@ -92,7 +91,7 @@ class PortMonitorStackManager:
     """
 
     def __init__(self) -> None:
-        """Initialize the PortMonitorStackManager and load configured stacks.
+        """Initialize the PortMonitorStackManager.
 
         The manager holds a list of PortMonitorStack objects and manages
         background monitoring state, docker client caching, and rate limiting
@@ -103,7 +102,7 @@ class PortMonitorStackManager:
         self.thread: threading.Thread | None = None
         self._docker_client: Any = None  # docker.DockerClient when available
         self._last_warning_times: dict[str, Any] = {}  # Rate limiting for warnings
-        self.load_stacks()
+        self._config_loaded: bool = False
 
     def _should_log_warning(self, key: str, min_interval: int = 30) -> bool:
         """Rate limit warnings to prevent log spam."""
@@ -119,19 +118,16 @@ class PortMonitorStackManager:
     def load_stacks(self) -> None:
         """Load stacks from the configured YAML file.
 
-        If the config file does not exist an empty stack list is used. Any
-        parse or IO errors are caught and logged; in that case the stacks
-        list will be empty.
+        If the config file does not exist an empty stack list is used. Store
+        corruption is propagated so startup cannot overwrite it with an empty
+        configuration; malformed stack entries are logged and ignored.
         """
-        if not Path(PORT_MONITOR_CONFIG_PATH).exists():
-            self.stacks = []
-            _logger.info("[PortMonitor] No config found at %s", PORT_MONITOR_CONFIG_PATH)
-            return
+        self._config_loaded = False
+        data = load_yaml_file(PORT_MONITOR_CONFIG_PATH, [], expected_type=list)
+
         try:
-            with PORT_MONITOR_CONFIG_PATH.open(encoding="utf-8") as f:
-                data = yaml.safe_load(f) or []
             seen = set()
-            unique_stacks = []
+            unique_stacks: list[PortMonitorStack] = []
             for d in data:
                 name = d["name"]
                 if name in seen:
@@ -153,35 +149,41 @@ class PortMonitorStackManager:
                     )
                 )
             self.stacks = unique_stacks
+            self._config_loaded = True
             _logger.info("[PortMonitorStack] Loaded stacks: %s", [s.name for s in self.stacks])
-        except Exception as e:
-            _logger.error("[PortMonitorStack] Failed to load stacks: %s", e)
-            self.stacks = []
+        except (KeyError, TypeError, ValueError) as e:
+            raise YamlStoreError(f"Invalid port-monitor stack configuration: {e}") from e
 
     def save_stacks(self) -> None:
         """Persist the current stack list to the configured YAML path.
 
-        Errors during writing are logged but not raised to the caller.
+        Raises:
+            YamlStoreError: If configuration was not loaded or persistence fails.
         """
+        if not self._config_loaded:
+            raise YamlStoreError("Port-monitor configuration is unavailable")
+        write_yaml_file(
+            PORT_MONITOR_CONFIG_PATH,
+            [
+                {
+                    "name": s.name,
+                    "primary_container": s.primary_container,
+                    "primary_port": s.primary_port,
+                    "secondary_containers": s.secondary_containers,
+                    "interval": getattr(s, "interval", 60),
+                    "public_ip": getattr(s, "public_ip", None),
+                    "public_ip_detected": getattr(s, "public_ip_detected", None),
+                }
+                for s in self.stacks
+            ],
+        )
+
+    def _save_stacks_best_effort(self) -> None:
+        """Persist runtime state without terminating background monitoring."""
         try:
-            with PORT_MONITOR_CONFIG_PATH.open("w", encoding="utf-8") as f:
-                yaml.safe_dump(
-                    [
-                        {
-                            "name": s.name,
-                            "primary_container": s.primary_container,
-                            "primary_port": s.primary_port,
-                            "secondary_containers": s.secondary_containers,
-                            "interval": getattr(s, "interval", 60),
-                            "public_ip": getattr(s, "public_ip", None),
-                            "public_ip_detected": getattr(s, "public_ip_detected", None),
-                        }
-                        for s in self.stacks
-                    ],
-                    f,
-                )
-        except Exception as e:
-            _logger.error("[PortMonitorStack] Failed to save stacks: %s", e)
+            self.save_stacks()
+        except YamlStoreError:
+            _logger.exception("[PortMonitorStack] Failed to persist background status update")
 
     def get_docker_client(self) -> Any:
         """Return a cached Docker client or create one from the environment.
@@ -359,7 +361,6 @@ class PortMonitorStackManager:
         """
         # Set status to 'Restarting...'
         stack.status = "Restarting..."
-        self.save_stacks()
 
         # Log restart event
         append_ui_event_log(
@@ -421,7 +422,7 @@ class PortMonitorStackManager:
                         "level": "warning",
                     }
                 )
-                await notify_event(
+                await safe_notify_event(
                     event_type="port_monitor_failure",
                     label=stack.name,
                     status="WARNING",
@@ -445,13 +446,14 @@ class PortMonitorStackManager:
                         "level": "error",
                     }
                 )
-                await notify_event(
+                await safe_notify_event(
                     event_type="port_monitor_failure",
                     label=stack.name,
                     status="ERROR",
                     message=f"Container {stack.primary_container} is not running after restart. Secondary containers not restarted.",
                     details={},
                 )
+                self.recheck_stack(stack.name)
                 return  # Do not restart secondaries
 
         # Restart all secondaries
@@ -475,6 +477,8 @@ class PortMonitorStackManager:
         If a stack with the same name already exists the operation is
         ignored.
         """
+        if not self._config_loaded:
+            raise YamlStoreError("Port-monitor configuration is unavailable")
         # Prevent duplicate stack names
         if any(s.name == name for s in self.stacks):
             _logger.warning(
@@ -490,7 +494,11 @@ class PortMonitorStackManager:
         stack.last_result = result
         stack.status = "OK" if result else "Failed"
         self.stacks.append(stack)
-        self.save_stacks()
+        try:
+            self.save_stacks()
+        except YamlStoreError:
+            self.stacks.remove(stack)
+            raise
 
         _logger.info(
             "[PortMonitorStack] Added stack '%s' with initial status: %s",
@@ -510,13 +518,20 @@ class PortMonitorStackManager:
         stack.last_checked = time.time()
         stack.last_result = result
         stack.status = "OK" if result else "Failed"
-        self.save_stacks()
+        self._save_stacks_best_effort()
         return True
 
     def remove_stack(self, name: str) -> None:
         """Remove a stack by name and persist the updated stack list."""
+        if not self._config_loaded:
+            raise YamlStoreError("Port-monitor configuration is unavailable")
+        previous_stacks = self.stacks
         self.stacks = [s for s in self.stacks if s.name != name]
-        self.save_stacks()
+        try:
+            self.save_stacks()
+        except YamlStoreError:
+            self.stacks = previous_stacks
+            raise
 
     def get_stack(self, name: str) -> PortMonitorStack | None:
         """Return the stack with the given name or None if not found."""
@@ -535,8 +550,6 @@ class PortMonitorStackManager:
         Periodically checks configured stacks and triggers restarts/notifications
         when a primary port is unreachable according to configured guardrails.
         """
-        self.running = True
-
         # Perform initial status checks immediately at startup
         _logger.info("[PortMonitorStack] Starting port monitoring with immediate initial checks...")
         for stack in self.stacks:
@@ -551,7 +564,7 @@ class PortMonitorStackManager:
                 stack.name,
                 "OK" if result else "FAILED",
             )
-        self.save_stacks()
+        self._save_stacks_best_effort()
         _logger.info(
             "[PortMonitorStack] Initial status checks complete, beginning periodic monitoring..."
         )
@@ -623,14 +636,14 @@ class PortMonitorStackManager:
                                         "level": "error",
                                     }
                                 )
-                                await notify_event(
+                                await safe_notify_event(
                                     event_type="port_monitor_failure",
                                     label=stack.name,
                                     status="ERROR",
                                     message=f"Manual IP {manual_ip} unreachable for 3+ cycles. Auto-restart paused until user updates or disables manual IP.",
                                     details={},
                                 )
-                                self.save_stacks()
+                                self._save_stacks_best_effort()
                                 continue  # Skip restart
                         else:
                             stack.consecutive_manual_ip_failures = 0
@@ -638,7 +651,7 @@ class PortMonitorStackManager:
                     if not result:
                         if getattr(stack, "manual_ip_paused", False):
                             continue  # Don't restart if paused
-                        await notify_event(
+                        await safe_notify_event(
                             event_type="port_monitor_failure",
                             label=stack.name,
                             status="FAILED",
@@ -651,27 +664,39 @@ class PortMonitorStackManager:
                             },
                         )
                         await self.restart_stack(stack)
-                    self.save_stacks()
+                    self._save_stacks_best_effort()
             await asyncio.sleep(5)
+
+    def _run_monitor_loop(self) -> None:
+        """Run the asynchronous monitor loop and release worker ownership."""
+        try:
+            asyncio.run(self.monitor_loop())
+        except Exception:
+            _logger.exception("[PortMonitorStack] Monitor loop terminated unexpectedly")
+            raise
+        finally:
+            self.running = False
 
     def start(self) -> None:
         """Start background monitoring in a daemon thread.
 
-        This initializes stack status and spawns the monitoring thread if it
-        is not already running.
+        This loads the optional configuration, initializes stack status, and
+        spawns the monitoring thread if it is not already running. Invalid
+        configuration disables monitoring without modifying the source file.
         """
-        self.load_stacks()
-        # Perform initial status checks for all stacks
-        for stack in self.stacks:
-            result = self.check_port(stack.primary_container, stack.primary_port)
-            stack.last_checked = time.time()
-            stack.last_result = result
-            stack.status = "OK" if result else "Failed"
-        self.save_stacks()
-        if not self.running:
-            self.thread = threading.Thread(
-                target=lambda: asyncio.run(self.monitor_loop()), daemon=True
+        try:
+            self.load_stacks()
+        except YamlStoreError as e:
+            self.running = False
+            self.stacks = []
+            _logger.error(
+                "[PortMonitorStack] Failed to load stacks; port monitoring disabled: %s",
+                e,
             )
+            return
+        if not self.running:
+            self.running = True
+            self.thread = threading.Thread(target=self._run_monitor_loop, daemon=True)
             self.thread.start()
 
     def stop(self) -> None:

--- a/backend/proxy_config.py
+++ b/backend/proxy_config.py
@@ -7,16 +7,13 @@ resolve inline proxy configs from session configuration structures.
 
 import logging
 from pathlib import Path
-import threading
 import time
 from typing import Any
 
-import yaml
-
 from backend.config import CONFIG_DIR
+from backend.yaml_store import load_yaml_file, write_yaml_file
 
 PROXIES_PATH = CONFIG_DIR / "proxies.yaml"
-_LOCK = threading.Lock()
 _logger: logging.Logger = logging.getLogger(__name__)
 _last_resolve_log_time: dict[str, float] = {}
 # Minimum seconds between identical resolve debug logs per proxy label/key
@@ -85,25 +82,15 @@ def resolve_proxy_from_session_cfg(cfg: dict[str, Any]) -> dict[str, Any] | None
 def load_proxies() -> dict[str, Any]:
     """Load proxies from PROXIES_PATH.
 
-    Returns a dict parsed from YAML or an empty dict if the file does not
-    exist or is empty. The _LOCK is used to synchronize file access.
+    Returns:
+        A parsed proxy mapping, or an empty mapping if the file is missing.
+
+    Raises:
+        YamlStoreError: If the existing file is invalid or not a mapping.
     """
-    try:
-        with _LOCK, Path(PROXIES_PATH).open(encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
-    except FileNotFoundError:
-        return {}
-    except yaml.YAMLError as e:
-        _logger.warning("[load_proxies] Malformed YAML at %s: %s", PROXIES_PATH, e)
-        return {}
+    return load_yaml_file(Path(PROXIES_PATH), {}, expected_type=dict)
 
 
 def save_proxies(proxies: dict[str, Any]) -> None:
-    """Persist the given proxies mapping to PROXIES_PATH as YAML.
-
-    Ensures the parent directory exists before attempting to write. Uses
-    the _LOCK to synchronize concurrent access.
-    """
-    Path(PROXIES_PATH).parent.mkdir(parents=True, exist_ok=True)
-    with _LOCK, Path(PROXIES_PATH).open("w", encoding="utf-8") as f:
-        yaml.safe_dump(proxies, f)
+    """Persist the given proxies mapping to PROXIES_PATH as YAML."""
+    write_yaml_file(Path(PROXIES_PATH), proxies)

--- a/backend/yaml_store.py
+++ b/backend/yaml_store.py
@@ -1,0 +1,107 @@
+"""Small, atomic YAML persistence helpers."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import yaml
+
+
+class YamlStoreError(RuntimeError):
+    """Raised when YAML persistence cannot satisfy its file contract."""
+
+
+def load_yaml_file(
+    path: Path,
+    default: Any,
+    expected_type: type[Any] | tuple[type[Any], ...] | None = None,
+) -> Any:
+    """Load one YAML file.
+
+    Args:
+        path: YAML file to load.
+        default: Value returned only when ``path`` does not exist.
+        expected_type: Optional required type for the parsed top-level value.
+
+    Returns:
+        The parsed YAML value, including ``None`` for an explicit YAML null.
+
+    Raises:
+        YamlStoreError: If the file is empty, unreadable, malformed, or has an
+            unexpected top-level type.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return default
+    except (OSError, UnicodeError) as err:
+        raise YamlStoreError(f"Could not read YAML file {path}: {err}") from err
+
+    if not text.strip():
+        raise YamlStoreError(f"YAML file is empty: {path}")
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as err:
+        raise YamlStoreError(f"Malformed YAML file {path}: {err}") from err
+    if expected_type is not None and not isinstance(data, expected_type):
+        raise YamlStoreError(
+            f"YAML file {path} has top-level type {type(data).__name__}; "
+            f"expected {_type_name(expected_type)}"
+        )
+    return data
+
+
+def write_yaml_file(path: Path, data: Any) -> None:
+    """Atomically write a YAML value through one same-directory temporary file.
+
+    Args:
+        path: Destination YAML path.
+        data: YAML-serializable value to persist.
+
+    Raises:
+        YamlStoreError: If serialization or persistence fails.
+    """
+    temp_path: Path | None = None
+    destination = path
+    try:
+        if destination.is_symlink():
+            raise YamlStoreError(f"Refusing to replace symlink YAML file {path}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            mode = destination.stat().st_mode & 0o7777
+        except FileNotFoundError:
+            mode = 0o600
+        descriptor, temp_name = tempfile.mkstemp(
+            prefix=".yaml-", suffix=".tmp", dir=destination.parent
+        )
+        temp_path = Path(temp_name)
+        try:
+            os.fchmod(descriptor, mode)
+        except OSError:
+            os.close(descriptor)
+            raise
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file_obj:
+            yaml.safe_dump(data, file_obj)
+            file_obj.flush()
+            os.fsync(file_obj.fileno())
+        temp_path.replace(destination)
+        temp_path = None
+    except YamlStoreError:
+        raise
+    except (OSError, yaml.YAMLError) as err:
+        raise YamlStoreError(f"Could not write YAML file {path}: {err}") from err
+    finally:
+        if temp_path is not None:
+            with suppress(OSError):
+                temp_path.unlink()
+
+
+def _type_name(expected_type: type[Any] | tuple[type[Any], ...]) -> str:
+    """Return a readable expected-type name for an error message."""
+    if isinstance(expected_type, tuple):
+        return " or ".join(item.__name__ for item in expected_type)
+    return expected_type.__name__

--- a/frontend/e2e/app.spec.js
+++ b/frontend/e2e/app.spec.js
@@ -1,0 +1,167 @@
+import { expect, test } from '@playwright/test';
+
+async function choose(page, label, option) {
+  await page.getByRole('combobox', { name: label, exact: true }).click();
+  await page.getByRole('option', { name: option, exact: true }).click();
+  await expect(page.getByRole('listbox')).toBeHidden();
+}
+
+test.describe
+  .serial('MouseTrap browser lifecycle', () => {
+    test.beforeEach(async ({ request }) => {
+      const sessions = await request.get('/api/sessions');
+      expect(sessions.ok()).toBeTruthy();
+      for (const label of (await sessions.json()).sessions) {
+        const deleted = await request.delete(`/api/session/delete/${encodeURIComponent(label)}`);
+        expect(deleted.ok()).toBeTruthy();
+      }
+
+      const proxies = await request.get('/api/proxies');
+      expect(proxies.ok()).toBeTruthy();
+      for (const label of Object.keys(await proxies.json())) {
+        const deleted = await request.delete(`/api/proxies/${encodeURIComponent(label)}`);
+        expect(deleted.ok()).toBeTruthy();
+      }
+
+      expect((await request.post('/api/notify/config', { data: {} })).ok()).toBeTruthy();
+      expect((await request.delete('/api/ui_event_log')).ok()).toBeTruthy();
+    });
+
+    test('starts with backend version and persists the selected theme', async ({ page }) => {
+      await page.goto('/');
+
+      await expect(page.getByText('MouseTrap').first()).toBeVisible();
+      await expect(page.getByText('ve2e', { exact: true })).toBeVisible();
+      await expect(page.getByText('Create a new session to get started.')).toBeVisible();
+
+      await page.getByLabel('toggle dark mode').check();
+      await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(18, 18, 18)');
+      await page.reload();
+      await expect(page.getByLabel('toggle dark mode')).toBeChecked();
+    });
+
+    test('creates, configures, renames, and deletes a session', async ({ page }) => {
+      await page.goto('/');
+      await page.getByRole('button', { name: 'Create New Session', exact: true }).click();
+
+      const config = page.getByText('Session Configuration', { exact: true });
+      await expect(page.getByLabel('Session Label')).toHaveValue('Session1');
+      await page.getByLabel('Session Label').fill('Primary');
+      await choose(page, 'Session Type', 'IP Locked');
+      await choose(page, 'IP Monitoring', 'Static (No Monitoring)');
+      await choose(page, 'Interval', '10');
+      await page.getByRole('textbox', { name: 'MAM ID', exact: true }).fill('e2e-mam-id');
+      await page.getByRole('textbox', { name: 'IP Address', exact: true }).fill('192.0.2.10');
+      await page.getByRole('button', { name: 'SAVE', exact: true }).click();
+      await expect(page.getByText('Session saved successfully.')).toBeVisible();
+
+      await page.reload();
+      await expect(page.getByRole('combobox', { name: 'Session', exact: true })).toContainText(
+        'Primary',
+      );
+      await config.click();
+      await expect(page.getByLabel('Session Label')).toBeVisible();
+      await expect(page.getByLabel('Session Label')).toHaveValue('Primary');
+
+      await page.getByRole('button', { name: 'Delete session' }).click();
+      await expect(page.getByRole('dialog', { name: 'Delete Session' })).toContainText('Primary');
+      await page.getByRole('button', { name: 'Delete', exact: true }).click();
+      await expect(page.getByText('Create a new session to get started.')).toBeVisible();
+    });
+
+    test('persists proxy CRUD, assigns it to a session, and records events', async ({ page }) => {
+      await page.goto('/');
+      await page.getByRole('button', { name: 'Create New Session', exact: true }).click();
+
+      await page.getByText('Proxy Configuration', { exact: true }).click();
+      await page.getByRole('textbox', { name: 'Label', exact: true }).fill('local-proxy');
+      await page.getByRole('textbox', { name: 'Host', exact: true }).fill('127.0.0.1');
+      await page.getByRole('spinbutton', { name: 'Port', exact: true }).fill('8080');
+      await page.getByRole('textbox', { name: 'Username', exact: true }).fill('tester');
+      await page.getByRole('button', { name: 'Save Proxy' }).click();
+      await expect(page.getByText('Proxy: local-proxy')).toBeVisible();
+
+      await page.reload();
+      await page.getByText('Session Configuration', { exact: true }).click();
+      await page.getByLabel('Session Label').fill('Proxied');
+      await choose(page, 'Session Type', 'ASN Locked');
+      await choose(page, 'IP Monitoring', 'Static (No Monitoring)');
+      await choose(page, 'Interval', '15');
+      await page.getByRole('textbox', { name: 'MAM ID', exact: true }).fill('e2e-proxy-mam-id');
+      await page.getByRole('textbox', { name: 'IP Address', exact: true }).fill('192.0.2.20');
+      await page.getByRole('combobox', { name: 'Proxy', exact: true }).click();
+      await page.getByRole('option', { name: /local-proxy/ }).click();
+      await expect(page.getByRole('listbox')).toBeHidden();
+      await page.getByRole('button', { name: 'SAVE', exact: true }).click();
+      await expect(page.getByText('Session saved successfully.')).toBeVisible();
+
+      await page.getByRole('button', { name: 'View event log' }).click();
+      await expect(page.getByRole('dialog', { name: 'Event Log' })).toContainText(
+        /Session 'Proxied' (created|saved)/,
+      );
+      await page.getByRole('button', { name: 'Clear event log' }).click();
+      await expect(page.getByText('No events yet.')).toBeVisible();
+      await page.getByRole('button', { name: 'Close event log' }).click();
+
+      await page.getByText('Proxy Configuration', { exact: true }).click();
+      await page.getByRole('button', { name: 'Edit proxy local-proxy' }).click();
+      await page.getByRole('spinbutton', { name: 'Port', exact: true }).fill('8081');
+      await page.getByRole('button', { name: 'Update Proxy' }).click();
+      await expect(page.getByText('Host: 127.0.0.1:8081')).toBeVisible();
+
+      await page.getByRole('button', { name: 'Delete proxy local-proxy' }).click();
+      await page.getByRole('button', { name: 'Delete', exact: true }).click();
+      await expect(page.getByText('No proxies configured.')).toBeVisible();
+    });
+
+    test('saves notification configuration without sending a notification', async ({ page }) => {
+      await page.goto('/');
+      await page.getByText('Notifications', { exact: true }).click();
+      await page.getByText('Configuration', { exact: true }).click();
+      await page
+        .getByRole('textbox', { name: 'Webhook URL', exact: true })
+        .fill('https://example.invalid/mousetrap-e2e');
+      await page.getByRole('button', { name: 'Save Settings' }).click();
+      await expect(page.getByText('Settings saved.')).toBeVisible();
+
+      await page.reload();
+      await page.getByText('Notifications', { exact: true }).click();
+      await page.getByText('Configuration', { exact: true }).click();
+      await expect(page.getByRole('textbox', { name: 'Webhook URL', exact: true })).toHaveValue(
+        'https://example.invalid/mousetrap-e2e',
+      );
+    });
+
+    test('shows a session save failure without persisting it', async ({ page, request }) => {
+      await request.post('/api/session/save', {
+        data: {
+          check_freq: 10,
+          label: 'FailureCase',
+          mam: {
+            ip_monitoring_mode: 'static',
+            mam_id: 'failure-case-mam-id',
+            session_type: 'IP Locked',
+          },
+          mam_ip: '192.0.2.30',
+        },
+      });
+      await page.goto('/');
+      await page.getByText('Session Configuration', { exact: true }).click();
+      await page.getByRole('textbox', { name: 'IP Address', exact: true }).fill('192.0.2.31');
+      await page.route('**/api/session/save', (route) =>
+        route.fulfill({ body: '{"detail":"simulated failure"}', status: 500 }),
+      );
+      await page.getByRole('button', { name: 'SAVE', exact: true }).click();
+      await expect(page.getByText('Error saving session: Failed to save session')).toBeVisible();
+
+      const persisted = await request.get('/api/session/FailureCase');
+      expect(persisted.ok()).toBeTruthy();
+      expect((await persisted.json()).mam_ip).toBe('192.0.2.30');
+
+      await page.reload();
+      await page.getByText('Session Configuration', { exact: true }).click();
+      await expect(page.getByRole('textbox', { name: 'IP Address', exact: true })).toHaveValue(
+        '192.0.2.30',
+      );
+    });
+  });

--- a/frontend/e2e/container-smoke.spec.js
+++ b/frontend/e2e/container-smoke.spec.js
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test('@container serves the production UI and preserves mounted configuration', async ({
+  page,
+  request,
+}) => {
+  test.skip(!process.env.E2E_BASE_URL, 'Set E2E_BASE_URL to a running production container');
+
+  const versionResponse = await request.get('/api/version');
+  expect(versionResponse.ok()).toBeTruthy();
+  expect(await versionResponse.json()).toEqual({ version: expect.any(String) });
+
+  const sessionsResponse = await request.get('/api/sessions');
+  expect(sessionsResponse.ok()).toBeTruthy();
+  expect(await sessionsResponse.json()).toEqual({ sessions: [] });
+
+  const proxiesResponse = await request.get('/api/proxies');
+  expect(proxiesResponse.ok()).toBeTruthy();
+  expect(await proxiesResponse.json()).toMatchObject({
+    'container-smoke-proxy': {
+      host: '127.0.0.1',
+      port: 8080,
+    },
+  });
+
+  await page.goto('/');
+  await expect(page.getByText('MouseTrap').first()).toBeVisible();
+  await expect(page.getByText('Create a new session to get started.')).toBeVisible();
+  await expect(page.getByText('Notifications', { exact: true })).toBeVisible();
+  await expect(page.getByText('Proxy Configuration', { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText('Create a new session to get started.')).toBeVisible();
+});

--- a/frontend/e2e/support/__init__.py
+++ b/frontend/e2e/support/__init__.py
@@ -1,0 +1,1 @@
+"""Support utilities for frontend end-to-end tests."""

--- a/frontend/e2e/support/backend_server.py
+++ b/frontend/e2e/support/backend_server.py
@@ -1,0 +1,53 @@
+"""Run the real FastAPI app with deterministic external-service boundaries."""
+
+import importlib
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import uvicorn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+app_module = importlib.import_module("backend.app")
+
+
+async def _public_ip(*_args: Any, **_kwargs: Any) -> str:
+    return "192.0.2.100"
+
+
+async def _ipinfo(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+    return {"asn": "AS64500", "ip": "192.0.2.100", "timezone": "UTC"}
+
+
+async def _asn(_ip: str, **_kwargs: Any) -> tuple[str, str]:
+    return "AS64500", "UTC"
+
+
+async def _mam_seen(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+    return {"AS": "TEST-NET", "ASN": "64500", "IP": "192.0.2.100"}
+
+
+async def _mam_status(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+    return {
+        "mam_cookie_exists": True,
+        "points": 0,
+        "status_message": "OK",
+        "vip_active": False,
+        "wedge_active": False,
+    }
+
+
+app_module.get_public_ip = _public_ip
+app_module.get_ipinfo_with_fallback = _ipinfo
+app_module.get_asn_and_timezone_from_ip = _asn
+app_module.get_mam_seen_ip_info = _mam_seen
+app_module.get_status = _mam_status
+importlib.import_module("backend.api_proxy").get_ipinfo_with_fallback = _ipinfo
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app_module.app,
+        host="127.0.0.1",
+        port=int(os.environ.get("E2E_BACKEND_PORT", "39852")),
+    )

--- a/frontend/e2e/support/global-teardown.js
+++ b/frontend/e2e/support/global-teardown.js
@@ -1,0 +1,12 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export default function globalTeardown() {
+  const configDir = process.env.MOUSETRAP_E2E_CONFIG_DIR;
+  const expectedPrefix = resolve(join(tmpdir(), 'mousetrap-playwright-'));
+
+  if (configDir && resolve(configDir).startsWith(expectedPrefix)) {
+    rmSync(configDir, { force: true, recursive: true });
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
+        "@playwright/test": "^1.62.0",
         "@vitejs/plugin-react": "^5.0.4",
         "concurrently": "^9.2.1",
         "typescript": "^5.9.2",
@@ -1343,6 +1344,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2819,6 +2836,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,9 @@
     "lint": "biome check . --config-path=./biome.json",
     "lint:fix": "biome check . --write --config-path=./biome.json",
     "tsc": "tsc --noEmit",
+    "test:e2e": "playwright test --grep-invert @container",
+    "test:e2e:container": "playwright test --grep @container",
+    "test:e2e:install": "playwright install chromium",
     "backend": "cd .. && ./scripts/start-backend.sh",
     "dev": "concurrently \"npm:backend\" \"npm:start\" -k --names \"backend,frontend\" --prefix \"[{name}]\""
   },
@@ -37,10 +40,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
+    "@playwright/test": "^1.62.0",
     "@vitejs/plugin-react": "^5.0.4",
     "concurrently": "^9.2.1",
+    "typescript": "^5.9.2",
     "vite": "^7.1.7",
-    "vite-plugin-svgr": "^4.5.0",
-    "typescript": "^5.9.2"
+    "vite-plugin-svgr": "^4.5.0"
   }
 }

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,73 @@
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+
+const externalBaseUrl = process.env.E2E_BASE_URL;
+const backendPort = '39852';
+const frontendPort = '5174';
+const localPython = resolve('../.venv/bin/python');
+const python = process.env.E2E_PYTHON || (existsSync(localPython) ? localPython : 'python3');
+const configDir = externalBaseUrl
+  ? undefined
+  : mkdtempSync(join(tmpdir(), 'mousetrap-playwright-'));
+if (configDir) {
+  process.env.MOUSETRAP_E2E_CONFIG_DIR = configDir;
+}
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  globalTeardown: externalBaseUrl ? undefined : './e2e/support/global-teardown.js',
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'line',
+  timeout: 30_000,
+  expect: { timeout: 7_500 },
+  use: {
+    baseURL: externalBaseUrl || `http://127.0.0.1:${frontendPort}`,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: externalBaseUrl
+    ? undefined
+    : [
+        {
+          command: `${python} frontend/e2e/support/backend_server.py`,
+          cwd: '..',
+          env: {
+            ...process.env,
+            APP_VERSION: 'e2e',
+            CONFIG_DIR: configDir,
+            E2E_BACKEND_PORT: backendPort,
+            NOTIFY_CONFIG_PATH: join(configDir, 'notify.yaml'),
+            PORT_MONITOR_CONFIG_PATH: join(configDir, 'port-monitoring.yaml'),
+          },
+          reuseExistingServer: false,
+          stderr: 'pipe',
+          stdout: 'pipe',
+          timeout: 30_000,
+          url: `http://127.0.0.1:${backendPort}/api/version`,
+        },
+        {
+          command: `npm run start -- --host 127.0.0.1 --port ${frontendPort} --strictPort`,
+          env: {
+            ...process.env,
+            VITE_BACKEND_URL: `http://127.0.0.1:${backendPort}`,
+          },
+          reuseExistingServer: false,
+          stderr: 'pipe',
+          stdout: 'pipe',
+          timeout: 30_000,
+          url: `http://127.0.0.1:${frontendPort}`,
+        },
+      ],
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -315,6 +315,7 @@ export default function App() {
           />
           <EventLogModalButton sessionLabel={selectedLabel} />
           <IconButton
+            aria-label={`use ${mode === 'light' ? 'dark' : 'light'} theme`}
             color="inherit"
             onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
             sx={{ ml: 2 }}

--- a/frontend/src/components/EventLogModalButton.jsx
+++ b/frontend/src/components/EventLogModalButton.jsx
@@ -155,7 +155,12 @@ export default function EventLogModalButton({ sessionLabel }) {
   return (
     <>
       <Tooltip title="View Event Log">
-        <IconButton color="inherit" onClick={() => setOpen(true)} size="medium">
+        <IconButton
+          aria-label="View event log"
+          color="inherit"
+          onClick={() => setOpen(true)}
+          size="medium"
+        >
           <DescriptionIcon />
         </IconButton>
       </Tooltip>
@@ -188,7 +193,12 @@ export default function EventLogModalButton({ sessionLabel }) {
           <DialogTitle sx={{ borderRadius: 0, p: 0 }}>Event Log</DialogTitle>
           <Box sx={{ borderRadius: 2 }}>
             <Tooltip title="Refresh">
-              <IconButton onClick={fetchLog} size="small" sx={{ mr: 1 }}>
+              <IconButton
+                aria-label="Refresh event log"
+                onClick={fetchLog}
+                size="small"
+                sx={{ mr: 1 }}
+              >
                 <svg
                   aria-label="Refresh"
                   fill="none"
@@ -210,7 +220,12 @@ export default function EventLogModalButton({ sessionLabel }) {
               </IconButton>
             </Tooltip>
             <Tooltip title="Clear log">
-              <IconButton onClick={handleClear} size="small" sx={{ mr: 1 }}>
+              <IconButton
+                aria-label="Clear event log"
+                onClick={handleClear}
+                size="small"
+                sx={{ mr: 1 }}
+              >
                 <svg
                   aria-label="Clear log"
                   fill="none"
@@ -235,7 +250,7 @@ export default function EventLogModalButton({ sessionLabel }) {
               </IconButton>
             </Tooltip>
             <Tooltip title="Close">
-              <IconButton onClick={() => setOpen(false)} size="small">
+              <IconButton aria-label="Close event log" onClick={() => setOpen(false)} size="small">
                 <CloseIcon fontSize="small" />
               </IconButton>
             </Tooltip>

--- a/frontend/src/components/MamDetailsAccordion.jsx
+++ b/frontend/src/components/MamDetailsAccordion.jsx
@@ -41,7 +41,7 @@ export default function MamDetailsAccordion({ status }) {
           sx={{
             display: 'grid',
             gap: 3,
-            gridTemplateColumns: '1fr 1fr',
+            gridTemplateColumns: { sm: '1fr 1fr', xs: '1fr' },
             m: 0,
             p: 0,
           }}

--- a/frontend/src/components/MouseTrapConfigCard.jsx
+++ b/frontend/src/components/MouseTrapConfigCard.jsx
@@ -326,6 +326,7 @@ export default function MouseTrapConfigCard({
               </InputLabel>
               <Select
                 error={showValidation && !!sessionTypeError}
+                inputProps={{ 'aria-label': 'Session Type' }}
                 label="Session Type"
                 MenuProps={{ disableScrollLock: true }}
                 onChange={(e) => setSessionType(e.target.value)}
@@ -343,6 +344,7 @@ export default function MouseTrapConfigCard({
               <FormControl size="small" sx={{ maxWidth: 175, minWidth: 130 }}>
                 <InputLabel>IP Monitoring</InputLabel>
                 <Select
+                  inputProps={{ 'aria-label': 'IP Monitoring' }}
                   label="IP Monitoring"
                   MenuProps={{ disableScrollLock: true }}
                   onChange={(e) => setIpMonitoringMode(/** @type {any} */ (e.target.value))}
@@ -381,6 +383,7 @@ export default function MouseTrapConfigCard({
               >
                 <InputLabel>Interval*</InputLabel>
                 <Select
+                  inputProps={{ 'aria-label': 'Interval' }}
                   label="Interval"
                   MenuProps={{ disableScrollLock: true }}
                   onChange={(e) => {
@@ -534,6 +537,7 @@ export default function MouseTrapConfigCard({
                   <InputLabel shrink>Proxy</InputLabel>
                   <Select
                     displayEmpty
+                    inputProps={{ 'aria-label': 'Proxy' }}
                     label="Proxy"
                     MenuProps={{
                       disableScrollLock: true,

--- a/frontend/src/components/NotificationsCard.jsx
+++ b/frontend/src/components/NotificationsCard.jsx
@@ -473,7 +473,16 @@ export default function NotificationsCard() {
             </Alert>
           )}
           <FormGroup sx={{ mb: 3 }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                minWidth: 0,
+                overflowX: 'auto',
+                width: '100%',
+              }}
+            >
               {/* Paired Events (Success/Failure) */}
               {pairedEvents.map((group) => (
                 <Box

--- a/frontend/src/components/ProxyConfigCard.jsx
+++ b/frontend/src/components/ProxyConfigCard.jsx
@@ -351,6 +351,7 @@ export default function ProxyConfigCard({ proxies, refreshProxies }) {
                         <Box>
                           <Tooltip title="Test Proxy">
                             <IconButton
+                              aria-label={`Test proxy ${label}`}
                               disabled={testingProxy === label}
                               onClick={() => handleTestProxy(label)}
                               size="small"
@@ -368,12 +369,20 @@ export default function ProxyConfigCard({ proxies, refreshProxies }) {
                             </IconButton>
                           </Tooltip>
                           <Tooltip title="Edit Proxy">
-                            <IconButton onClick={() => handleEdit(label)} size="small">
+                            <IconButton
+                              aria-label={`Edit proxy ${label}`}
+                              onClick={() => handleEdit(label)}
+                              size="small"
+                            >
                               <EditIcon color="primary" fontSize="small" />
                             </IconButton>
                           </Tooltip>
                           <Tooltip title="Delete Proxy">
-                            <IconButton onClick={() => handleDelete(label)} size="small">
+                            <IconButton
+                              aria-label={`Delete proxy ${label}`}
+                              onClick={() => handleDelete(label)}
+                              size="small"
+                            >
                               <DeleteIcon color="error" fontSize="small" />
                             </IconButton>
                           </Tooltip>

--- a/frontend/src/components/SessionSelector.jsx
+++ b/frontend/src/components/SessionSelector.jsx
@@ -77,6 +77,7 @@ export default function SessionSelector({ onLoadSession, onCreateSession, onDele
       <FormControl size="small" sx={{ maxWidth: 240, minWidth: 160 }}>
         <InputLabel>Session</InputLabel>
         <Select
+          inputProps={{ 'aria-label': 'Session' }}
           label="Session"
           MenuProps={{ disableScrollLock: true }}
           onChange={handleChange}
@@ -92,6 +93,7 @@ export default function SessionSelector({ onLoadSession, onCreateSession, onDele
       </FormControl>
       <Tooltip title="Create New Session">
         <IconButton
+          aria-label="Create new session"
           color="success"
           onClick={() => {
             const maybePromise = onCreateSession?.();
@@ -109,6 +111,7 @@ export default function SessionSelector({ onLoadSession, onCreateSession, onDele
       <Tooltip title="Delete Session">
         <span>
           <IconButton
+            aria-label="Delete session"
             color="error"
             disabled={sessions.length === 0}
             onClick={handleDeleteClick}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
 		"lint:fix": "cd frontend && npm run lint:fix",
 		"tsc": "cd frontend && npm run tsc",
 		"backend": "cd frontend && npm run backend",
-		"dev": "cd frontend && npm run dev"
+		"dev": "cd frontend && npm run dev",
+		"test:backend:integration": "python -m pytest -m integration",
+		"test:backend:workflow": "python -m pytest -m workflow",
+		"test:backend:all": "python -m pytest",
+		"test:e2e": "npm --prefix frontend run test:e2e",
+		"test:e2e:container": "npm --prefix frontend run test:e2e:container"
 	}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ addopts = """
 """
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "integration: public API tests spanning multiple backend modules",
+    "workflow: end-to-end user workflow tests through the ASGI boundary",
+]
 
 [tool.coverage.run]
 branch = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,7 @@
 # Lint includes the full requirements.txt
 -r requirements-lint.txt
+httpx
+pytest
+pytest-asyncio
+pytest-cov
+pytest-timeout

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(dirname -- "$SCRIPT_DIR")"
+VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
+FRONTEND_DIR="$REPO_ROOT/frontend"
+
+if [ ! -x "$VENV_PYTHON" ]; then
+  echo "Missing repository virtual environment: $VENV_PYTHON" >&2
+  echo "Create .venv and install requirements-dev.txt before running tests." >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to run the frontend test suite." >&2
+  exit 1
+fi
+
+if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
+  echo "Missing frontend dependencies. Run: cd frontend && npm ci" >&2
+  exit 1
+fi
+
+echo "Running backend tests..."
+(
+  cd "$REPO_ROOT"
+  "$VENV_PYTHON" -m pytest
+)
+
+echo "Running frontend end-to-end tests..."
+npm --prefix "$FRONTEND_DIR" run test:e2e

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 set -eu
 
+# Run the complete local test gate:
+#   1. Execute the full backend pytest suite in the repository virtual environment.
+#   2. Execute the Playwright development E2E suite against isolated FastAPI and
+#      Vite servers with temporary application configuration.
+# The production-container smoke suite is intentionally left to GitHub Actions.
+
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(dirname -- "$SCRIPT_DIR")"
 VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
 FRONTEND_DIR="$REPO_ROOT/frontend"
 
+# Fail early with actionable setup instructions instead of partially running the gate.
 if [ ! -x "$VENV_PYTHON" ]; then
   echo "Missing repository virtual environment: $VENV_PYTHON" >&2
   echo "Create .venv and install requirements-dev.txt before running tests." >&2
@@ -24,9 +31,11 @@ fi
 
 echo "Running backend tests..."
 (
+  # Run from the repository root so pytest uses the project configuration.
   cd "$REPO_ROOT"
   "$VENV_PYTHON" -m pytest
 )
 
 echo "Running frontend end-to-end tests..."
+# Playwright's configuration starts and cleans up the isolated development servers.
 npm --prefix "$FRONTEND_DIR" run test:e2e

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend regression tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared pytest configuration for backend tests."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,53 @@
 """Shared pytest configuration for backend tests."""
 
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 import sys
+
+from httpx import ASGITransport, AsyncClient
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend import (  # noqa: E402
+    api_notifications,
+    config,
+    db,
+    last_session_api,
+    notifications_backend,
+    port_monitor,
+    proxy_config,
+)
+from backend.app import app  # noqa: E402
+
+
+@pytest.fixture
+def isolated_backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Redirect every backend persistence boundary to a temporary directory."""
+    db._get_conn.cache_clear()
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / "config.yaml")
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "mousetrap.db")
+    monkeypatch.setattr(proxy_config, "PROXIES_PATH", tmp_path / "proxies.yaml")
+    monkeypatch.setattr(notifications_backend, "NOTIFY_CONFIG_PATH", tmp_path / "notify.yaml")
+    monkeypatch.setattr(api_notifications, "NOTIFY_CONFIG_PATH", tmp_path / "notify.yaml")
+    monkeypatch.setattr(last_session_api, "LAST_SESSION_FILE", tmp_path / "last_session.yaml")
+    monkeypatch.setattr(
+        port_monitor,
+        "PORT_MONITOR_CONFIG_PATH",
+        tmp_path / "port_monitoring_stacks.yaml",
+    )
+    port_monitor.port_monitor_manager.stacks = []
+    port_monitor.port_monitor_manager._config_loaded = True
+    yield tmp_path
+    db._get_conn.cache_clear()
+
+
+@pytest.fixture
+async def api_client(isolated_backend: Path) -> AsyncIterator[AsyncClient]:
+    """Expose the public FastAPI surface without running background startup jobs."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Backend integration tests."""

--- a/tests/integration/test_notifications_indexer.py
+++ b/tests/integration/test_notifications_indexer.py
@@ -1,0 +1,100 @@
+"""Integration tests for deterministic external-service seams."""
+
+from httpx import AsyncClient
+import pytest
+
+from backend import api_notifications, app
+
+
+@pytest.mark.integration
+async def test_notification_config_and_webhook_dispatch(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Persist notification settings and dispatch through the fake webhook seam."""
+    sent: list[tuple[str, dict, bool]] = []
+
+    async def fake_send(url: str, payload: dict, discord: bool = False) -> bool:
+        sent.append((url, payload, discord))
+        return True
+
+    monkeypatch.setattr(api_notifications, "send_webhook_notification", fake_send)
+    config = {"webhook_url": "https://notify.invalid/hook", "discord_webhook": True}
+    assert (await api_client.post("/api/notify/config", json=config)).json() == {"success": True}
+    assert (await api_client.get("/api/notify/config")).json() == config
+
+    payload = {"message": "integration test"}
+    assert (await api_client.post("/api/notify/test/webhook", json=payload)).json() == {
+        "success": True
+    }
+    assert sent == [("https://notify.invalid/hook", payload, True)]
+
+
+@pytest.mark.integration
+async def test_prowlarr_public_api_composes_connection_and_indexer_results(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise representative indexer behavior without a live Prowlarr server."""
+
+    async def connected(_host: str, _port: int, _api_key: str) -> dict:
+        return {"success": True, "message": "Connected", "indexer_count": 3}
+
+    async def found(_host: str, _port: int, _api_key: str) -> dict:
+        return {"success": True, "indexer_id": 42}
+
+    monkeypatch.setattr(app, "test_prowlarr_connection", connected)
+    monkeypatch.setattr(app, "find_mam_indexer_id", found)
+    response = await api_client.post(
+        "/api/prowlarr/test",
+        json={"host": "prowlarr.local", "port": 9696, "api_key": "secret"},
+    )
+    assert response.json() == {
+        "success": True,
+        "message": "Connected",
+        "indexer_count": 3,
+        "indexer_id": 42,
+    }
+
+
+@pytest.mark.integration
+async def test_webhook_requires_configuration(api_client: AsyncClient) -> None:
+    """Expose missing notification configuration as a stable client error."""
+    response = await api_client.post("/api/notify/test/webhook", json={"message": "test"})
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Webhook URL not set."}
+
+
+@pytest.mark.integration
+async def test_unified_indexer_update_reports_partial_success(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep one successful MAM-ID sync observable when another integration times out."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    session = {
+        "label": "seedbox",
+        "mam": {"mam_id": "new-cookie"},
+        "proxy": {},
+        "prowlarr": {"enabled": True},
+        "chaptarr": {"enabled": True},
+    }
+    assert (await api_client.post("/api/session/save", json=session)).is_success
+
+    async def prowlarr_success(_cfg: dict, mam_id: str) -> dict:
+        assert mam_id == "new-cookie"
+        return {"success": True, "message": "updated"}
+
+    async def chaptarr_timeout(_cfg: dict, mam_id: str) -> dict:
+        assert mam_id == "new-cookie"
+        raise TimeoutError("service timed out")
+
+    monkeypatch.setattr(app, "sync_mam_id_to_prowlarr", prowlarr_success)
+    monkeypatch.setattr(app, "sync_mam_id_to_chaptarr", chaptarr_timeout)
+    response = await api_client.post("/api/indexer/update", json={"label": "seedbox"})
+
+    assert response.json() == {
+        "success": True,
+        "message": ("Partially successful: Updated Prowlarr. Failed: Chaptarr (service timed out)"),
+        "warning": True,
+    }
+    events = (await api_client.get("/api/ui_event_log")).json()
+    assert events[-1]["event"] == "indexer_partial_update"
+    assert events[-1]["event_type"] == "indexer_update"

--- a/tests/integration/test_session_proxy_events.py
+++ b/tests/integration/test_session_proxy_events.py
@@ -1,0 +1,61 @@
+"""Public-API integration coverage for sessions, proxies, and event persistence."""
+
+from pathlib import Path
+
+from httpx import AsyncClient
+import pytest
+
+from backend import app
+
+
+@pytest.mark.integration
+async def test_session_lifecycle_persists_events(
+    api_client: AsyncClient, isolated_backend: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Create, read, update, and delete a session through HTTP."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    payload = {"label": "seedbox", "mam": {"mam_id": "cookie-one"}, "proxy": {}}
+
+    created = await api_client.post("/api/session/save", json=payload)
+    assert created.json() == {"success": True}
+    assert (isolated_backend / "session-seedbox.yaml").exists()
+    assert (await api_client.get("/api/sessions")).json() == {"sessions": ["seedbox"]}
+    assert (await api_client.get("/api/session/seedbox")).json()["mam"]["mam_id"] == "cookie-one"
+
+    payload["mam"]["mam_id"] = "cookie-two"
+    payload["old_label"] = "seedbox"
+    payload["label"] = "archive"
+    assert (await api_client.post("/api/session/save", json=payload)).json() == {"success": True}
+    assert not (isolated_backend / "session-seedbox.yaml").exists()
+    assert (isolated_backend / "session-archive.yaml").exists()
+    assert (await api_client.get("/api/sessions")).json() == {"sessions": ["archive"]}
+
+    selected = await api_client.post("/api/last_session", json={"label": "archive"})
+    assert selected.json() == {"success": True, "label": "archive"}
+    assert (await api_client.get("/api/last_session")).json() == {"label": "archive"}
+    events = (await api_client.get("/api/ui_event_log")).json()
+    assert [event["event"] for event in events] == ["session_created", "session_created"]
+
+    assert (await api_client.delete("/api/session/delete/archive")).json() == {"success": True}
+    assert (await api_client.get("/api/sessions")).json() == {"sessions": []}
+    assert (await api_client.get("/api/last_session")).json() == {"label": ""}
+    assert [event["event"] for event in (await api_client.get("/api/ui_event_log")).json()] == [
+        "session_created",
+        "session_deleted",
+    ]
+
+
+@pytest.mark.integration
+async def test_deleting_proxy_cascades_to_session(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deleting a named proxy removes its reference from every saved session."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    proxy = {"label": "vpn", "host": "proxy.local", "port": 1080}
+    assert (await api_client.post("/api/proxies", json=proxy)).json() == {"success": True}
+    session = {"label": "seedbox", "mam": {"mam_id": "cookie"}, "proxy": {"label": "vpn"}}
+    assert (await api_client.post("/api/session/save", json=session)).is_success
+
+    assert (await api_client.delete("/api/proxies/vpn")).json() == {"success": True}
+    assert (await api_client.get("/api/proxies")).json() == {}
+    assert (await api_client.get("/api/session/seedbox")).json()["proxy"] == {}

--- a/tests/test_api_proxy.py
+++ b/tests/test_api_proxy.py
@@ -1,0 +1,29 @@
+"""Focused proxy-cleanup persistence tests."""
+
+from typing import Any
+
+import pytest
+
+from backend import api_proxy
+from backend.yaml_store import YamlStoreError
+
+
+def test_delete_proxy_skips_corrupt_session_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt session must not prevent cleanup of later valid sessions."""
+    saved: list[dict[str, Any]] = []
+    monkeypatch.setattr(api_proxy, "load_proxies", lambda: {"VPN": {}})
+    monkeypatch.setattr(api_proxy, "save_proxies", lambda _proxies: None)
+    monkeypatch.setattr(api_proxy, "list_sessions", lambda: ["bad", "good"])
+
+    def load(label: str) -> dict[str, Any]:
+        if label == "bad":
+            raise YamlStoreError("malformed")
+        return {"label": label, "proxy": {"label": "VPN"}}
+
+    monkeypatch.setattr(api_proxy, "load_session", load)
+    monkeypatch.setattr(api_proxy, "save_session", saved.append)
+
+    assert api_proxy.delete_proxy("VPN") == {"success": True}
+    assert saved == [{"label": "good", "proxy": {}}]

--- a/tests/test_app_scheduler.py
+++ b/tests/test_app_scheduler.py
@@ -1,0 +1,27 @@
+"""Focused scheduler persistence tests."""
+
+import logging
+
+import pytest
+
+from backend import app
+from backend.yaml_store import YamlStoreError
+
+
+def test_register_all_session_jobs_skips_malformed_session(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Continue registering jobs after one session fails YAML loading."""
+    registered: list[str] = []
+
+    def register(label: str) -> None:
+        if label == "broken":
+            raise YamlStoreError("malformed")
+        registered.append(label)
+
+    monkeypatch.setattr(app, "list_sessions", lambda: ["first", "broken", "last"])
+    monkeypatch.setattr(app, "register_session_job", register)
+    with caplog.at_level(logging.ERROR):
+        app.register_all_session_jobs()
+    assert registered == ["first", "last"]
+    assert "broken" in caplog.text

--- a/tests/test_app_session_save.py
+++ b/tests/test_app_session_save.py
@@ -4,7 +4,6 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from fastapi import HTTPException
 import pytest
 
 from backend import app, config
@@ -46,29 +45,35 @@ def test_save_persists_once_before_side_effects(
     assert calls == ["save", "clear", "event", "job", "sync"]
 
 
-def test_save_does_not_overwrite_corrupt_existing_session(
+def test_save_replaces_corrupt_existing_session(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Loading existing corrupt YAML fails before persistence."""
+    """Valid UI data replaces corrupt YAML without preserving invalid fields."""
     monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
     corrupt = config.get_session_path("Existing")
     corrupt.write_text("mam: [unterminated\n", encoding="utf-8")
     monkeypatch.setattr(app, "get_session_path", config.get_session_path)
-    monkeypatch.setattr(app, "save_session", lambda *_a, **_k: pytest.fail("must not persist"))
-    with pytest.raises(HTTPException) as raised:
-        asyncio.run(
-            app.api_save_session(
-                JsonRequest(
-                    {
-                        "label": "Existing",
-                        "old_label": "Existing",
-                        "mam": {"mam_id": "new"},
-                    }
-                )
+    monkeypatch.setattr(app, "append_ui_event_log", lambda _event: None)
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+
+    async def sync(*_args: Any) -> None:
+        return None
+
+    monkeypatch.setattr(app, "_sync_integrations_if_mam_id_changed", sync)
+    result = asyncio.run(
+        app.api_save_session(
+            JsonRequest(
+                {
+                    "label": "Existing",
+                    "old_label": "Existing",
+                    "mam": {"mam_id": "new"},
+                }
             )
         )
-    assert raised.value.status_code == 500
-    assert corrupt.read_text(encoding="utf-8") == "mam: [unterminated\n"
+    )
+
+    assert result == {"success": True}
+    assert config.load_session("Existing")["mam"]["mam_id"] == "new"
 
 
 def test_post_save_side_effect_failure_returns_success(

--- a/tests/test_app_session_save.py
+++ b/tests/test_app_session_save.py
@@ -1,0 +1,92 @@
+"""Focused API session-persistence tests."""
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException
+import pytest
+
+from backend import app, config
+
+
+class JsonRequest:
+    """Minimal request double."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        """Store the request body."""
+        self.payload = payload
+
+    async def json(self) -> dict[str, Any]:
+        """Return the configured request body."""
+        return self.payload
+
+
+def test_save_persists_once_before_side_effects(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Persist exactly once before event, scheduler, and integration work."""
+    calls: list[str] = []
+    path = tmp_path / "session-example.yaml"
+    monkeypatch.setattr(app, "load_session", lambda _label: {})
+    monkeypatch.setattr(app, "get_session_path", lambda _label: path)
+    monkeypatch.setattr(app, "save_session", lambda *_a, **_k: calls.append("save"))
+    monkeypatch.setattr(app, "clear_ui_event_log_for_session", lambda _label: calls.append("clear"))
+    monkeypatch.setattr(app, "append_ui_event_log", lambda _event: calls.append("event"))
+    monkeypatch.setattr(app, "register_session_job", lambda _label: calls.append("job"))
+
+    async def sync(*_args: Any) -> None:
+        calls.append("sync")
+
+    monkeypatch.setattr(app, "_sync_integrations_if_mam_id_changed", sync)
+    result = asyncio.run(
+        app.api_save_session(JsonRequest({"label": "Example", "mam": {"mam_id": "id"}}))
+    )
+    assert result == {"success": True}
+    assert calls == ["save", "clear", "event", "job", "sync"]
+
+
+def test_save_does_not_overwrite_corrupt_existing_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Loading existing corrupt YAML fails before persistence."""
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    corrupt = config.get_session_path("Existing")
+    corrupt.write_text("mam: [unterminated\n", encoding="utf-8")
+    monkeypatch.setattr(app, "get_session_path", config.get_session_path)
+    monkeypatch.setattr(app, "save_session", lambda *_a, **_k: pytest.fail("must not persist"))
+    with pytest.raises(HTTPException) as raised:
+        asyncio.run(
+            app.api_save_session(
+                JsonRequest(
+                    {
+                        "label": "Existing",
+                        "old_label": "Existing",
+                        "mam": {"mam_id": "new"},
+                    }
+                )
+            )
+        )
+    assert raised.value.status_code == 500
+    assert corrupt.read_text(encoding="utf-8") == "mam: [unterminated\n"
+
+
+def test_post_save_side_effect_failure_returns_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Report success once persistence committed even if later work fails."""
+    calls: list[str] = []
+    monkeypatch.setattr(app, "load_session", lambda _label: {})
+    monkeypatch.setattr(app, "get_session_path", lambda _label: tmp_path / "session.yaml")
+    monkeypatch.setattr(app, "save_session", lambda *_a, **_k: calls.append("save"))
+
+    def fail_clear(_label: str) -> None:
+        calls.append("clear")
+        raise RuntimeError("event log unavailable")
+
+    monkeypatch.setattr(app, "clear_ui_event_log_for_session", fail_clear)
+    result = asyncio.run(
+        app.api_save_session(JsonRequest({"label": "Example", "mam": {"mam_id": "id"}}))
+    )
+    assert result == {"success": True}
+    assert calls == ["save", "clear"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,106 @@
+"""Focused tests for session configuration lifecycle behavior."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend import config
+from backend.yaml_store import YamlStoreError
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point configuration persistence at an isolated directory."""
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / "config.yaml")
+    return tmp_path
+
+
+def test_missing_session_returns_defaults(config_dir: Path) -> None:
+    """Return normalized defaults when a primary session is absent."""
+    loaded = config.load_session("Missing")
+    assert loaded["label"] == "Missing"
+    assert loaded["browser_cookie"] == ""
+
+
+@pytest.mark.parametrize("contents", ["broken: [", "- wrong\n- shape\n"])
+def test_invalid_session_yaml_raises(config_dir: Path, contents: str) -> None:
+    """Expose corrupt and wrong-shaped persisted YAML as store errors."""
+    config.get_session_path("Bad").write_text(contents, encoding="utf-8")
+    with pytest.raises(YamlStoreError):
+        config.load_session("Bad")
+
+
+@pytest.mark.parametrize(
+    ("contents", "section"),
+    [
+        ("perk_automation: []\n", "perk_automation"),
+        ("perk_automation:\n  upload_credit: []\n", "perk_automation.upload_credit"),
+        ("perk_automation:\n  wedge_automation: []\n", "perk_automation.wedge_automation"),
+        ("perk_automation:\n  vip_automation: []\n", "perk_automation.vip_automation"),
+        ("mam: []\n", "mam"),
+        ("prowlarr: []\n", "prowlarr"),
+    ],
+)
+def test_invalid_nested_session_mapping_raises(
+    config_dir: Path, contents: str, section: str
+) -> None:
+    """Reject wrong-shaped session sections before mutating defaults."""
+    config.get_session_path("Bad").write_text(contents, encoding="utf-8")
+    with pytest.raises(YamlStoreError, match=rf"'{section}' must be a mapping"):
+        config.load_session("Bad")
+
+
+def test_save_update_rename_and_delete(config_dir: Path) -> None:
+    """Support the complete primary-file lifecycle."""
+    config.save_session({"label": "Old", "value": 1})
+    config.save_session({"label": "Old", "value": 2}, old_label="Old")
+    config.save_session({"label": "New", "value": 3}, old_label="Old")
+    assert config.list_sessions() == ["New"]
+    assert config.load_session("New")["value"] == 3
+    config.delete_session("New")
+    assert config.list_sessions() == []
+
+
+def test_rename_write_failure_preserves_old_session(
+    config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep the source session intact when writing its renamed copy fails."""
+    config.save_session({"label": "Old", "value": 1})
+    old_path = config.get_session_path("Old")
+    new_path = config.get_session_path("New")
+
+    def fail_write(_path: Path, _data: dict[str, Any]) -> None:
+        """Simulate an ordinary destination write failure."""
+        raise YamlStoreError("disk full")
+
+    monkeypatch.setattr(config, "write_yaml_file", fail_write)
+
+    with pytest.raises(YamlStoreError, match="disk full"):
+        config.save_session({"label": "New", "value": 2}, old_label="Old")
+
+    assert config.load_session("Old")["value"] == 1
+    assert old_path.exists()
+    assert not new_path.exists()
+
+
+def test_rename_unlink_failure_leaves_two_complete_sessions(
+    config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Propagate old-file cleanup failure after writing the complete new file."""
+    config.save_session({"label": "Old", "value": 1})
+    old_path = config.get_session_path("Old")
+    real_unlink = Path.unlink
+
+    def fail_old_unlink(path: Path, *args: Any, **kwargs: Any) -> None:
+        if path == old_path:
+            raise OSError("unlink denied")
+        real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_old_unlink)
+    with pytest.raises(OSError, match="unlink denied"):
+        config.save_session({"label": "New", "value": 2}, old_label="Old")
+
+    assert config.load_session("Old")["value"] == 1
+    assert config.load_session("New")["value"] == 2

--- a/tests/test_port_monitor.py
+++ b/tests/test_port_monitor.py
@@ -1,0 +1,221 @@
+"""Focused port-monitor persistence tests."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend import api_port_monitor, notifications_backend, port_monitor
+from backend.yaml_store import YamlStoreError
+
+
+def test_constructor_does_not_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Construction has no configuration I/O side effect."""
+    monkeypatch.setattr(
+        port_monitor.PortMonitorStackManager,
+        "load_stacks",
+        lambda _self: pytest.fail("must not load"),
+    )
+    manager = port_monitor.PortMonitorStackManager()
+    assert manager.stacks == []
+    assert not manager._config_loaded
+
+
+def test_start_contains_invalid_config_without_overwrite(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Invalid persisted YAML disables startup and remains untouched."""
+    path = tmp_path / "port_monitor.yaml"
+    contents = "broken: [\n"
+    path.write_text(contents, encoding="utf-8")
+    monkeypatch.setattr(port_monitor, "PORT_MONITOR_CONFIG_PATH", path)
+    manager = port_monitor.PortMonitorStackManager()
+    manager.start()
+    assert not manager.running
+    assert not manager._config_loaded
+    assert path.read_text(encoding="utf-8") == contents
+    with pytest.raises(YamlStoreError):
+        manager.add_stack("x", "container", 80, [])
+
+
+def test_loaded_manager_writes_with_shared_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A successfully loaded configuration can be mutated and persisted."""
+    path = tmp_path / "port_monitor.yaml"
+    monkeypatch.setattr(port_monitor, "PORT_MONITOR_CONFIG_PATH", path)
+    manager = port_monitor.PortMonitorStackManager()
+    manager.load_stacks()
+    manager.add_stack("x", "container", 80, [])
+    assert "name: x" in path.read_text(encoding="utf-8")
+
+
+def test_save_stacks_propagates_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expose persistence failure to API mutations and the monitor worker."""
+    manager = port_monitor.PortMonitorStackManager()
+    manager._config_loaded = True
+
+    def fail_write(_path: Path, _data: object) -> None:
+        raise YamlStoreError("disk full")
+
+    monkeypatch.setattr(port_monitor, "write_yaml_file", fail_write)
+    with pytest.raises(YamlStoreError, match="disk full"):
+        manager.save_stacks()
+
+
+def test_recheck_updates_status_when_background_save_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime rechecks succeed even when their best-effort save fails."""
+    manager = port_monitor.PortMonitorStackManager()
+    stack = port_monitor.PortMonitorStack("x", "container", 80, [])
+    manager.stacks = [stack]
+    monkeypatch.setattr(manager, "check_port", lambda *_args: True)
+    monkeypatch.setattr(manager, "save_stacks", lambda: (_ for _ in ()).throw(YamlStoreError()))
+
+    assert manager.recheck_stack("x")
+    assert stack.status == "OK"
+    assert stack.last_result is True
+
+
+def test_run_monitor_loop_logs_reraises_and_clears_running(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Expose unexpected worker failures while releasing running state."""
+    manager = port_monitor.PortMonitorStackManager()
+    manager.running = True
+    monitor_loop = AsyncMock(side_effect=RuntimeError("worker failed"))
+    monkeypatch.setattr(manager, "monitor_loop", monitor_loop)
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        manager._run_monitor_loop()
+
+    monitor_loop.assert_awaited_once_with()
+    assert not manager.running
+    assert "Monitor loop terminated unexpectedly" in caplog.text
+
+
+def test_notification_failure_does_not_block_restart_or_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contain optional notification failure during a failed port check."""
+    manager = port_monitor.PortMonitorStackManager()
+    manager._config_loaded = True
+    manager.running = True
+    stack = port_monitor.PortMonitorStack("x", "container", 80, [], 0)
+    manager.stacks = [stack]
+    monkeypatch.setattr(manager, "check_port", lambda *_args: False)
+    restart = AsyncMock()
+    monkeypatch.setattr(manager, "restart_stack", restart)
+    monkeypatch.setattr(port_monitor, "append_ui_event_log", lambda _event: None)
+    saves: list[bool] = []
+    monkeypatch.setattr(manager, "save_stacks", lambda: saves.append(True))
+    monkeypatch.setattr(
+        notifications_backend,
+        "notify_event",
+        AsyncMock(side_effect=RuntimeError("invalid notify config")),
+    )
+
+    async def stop_after_cycle(_delay: float) -> None:
+        manager.running = False
+
+    monkeypatch.setattr(port_monitor.asyncio, "sleep", stop_after_cycle)
+    asyncio.run(manager.monitor_loop())
+
+    restart.assert_awaited_once_with(stack)
+    assert len(saves) == 2
+
+
+def test_background_save_failure_does_not_block_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient status write failure does not stop the monitor cycle."""
+    manager = port_monitor.PortMonitorStackManager()
+    manager.running = True
+    stack = port_monitor.PortMonitorStack("x", "container", 80, [], 0)
+    manager.stacks = [stack]
+    monkeypatch.setattr(manager, "check_port", lambda *_args: False)
+    monkeypatch.setattr(manager, "save_stacks", lambda: (_ for _ in ()).throw(YamlStoreError()))
+    monkeypatch.setattr(port_monitor, "append_ui_event_log", lambda _event: None)
+    monkeypatch.setattr(port_monitor, "safe_notify_event", AsyncMock())
+    restart = AsyncMock()
+    monkeypatch.setattr(manager, "restart_stack", restart)
+
+    async def stop_after_cycle(_delay: float) -> None:
+        manager.running = False
+
+    monkeypatch.setattr(port_monitor.asyncio, "sleep", stop_after_cycle)
+    asyncio.run(manager.monitor_loop())
+    restart.assert_awaited_once_with(stack)
+
+
+@pytest.mark.parametrize("port_ok", [True, False])
+def test_restart_rechecks_once_on_completion_paths(
+    monkeypatch: pytest.MonkeyPatch, port_ok: bool
+) -> None:
+    """Manager-owned restart completion performs exactly one status recheck."""
+    manager = port_monitor.PortMonitorStackManager()
+    stack = port_monitor.PortMonitorStack("x", "container", 80, ["secondary"])
+    manager.stacks = [stack]
+    monkeypatch.setattr(manager, "restart_container", lambda _name: True)
+    monkeypatch.setattr(manager, "check_port", lambda *_args: port_ok)
+    monkeypatch.setattr(manager, "get_docker_client", lambda: None)
+    monkeypatch.setattr(port_monitor.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(port_monitor, "append_ui_event_log", lambda _event: None)
+    monkeypatch.setattr(port_monitor, "safe_notify_event", AsyncMock())
+    recheck = Mock(return_value=True)
+    monkeypatch.setattr(manager, "recheck_stack", recheck)
+
+    asyncio.run(manager.restart_stack(stack))
+    recheck.assert_called_once_with("x")
+
+
+@pytest.mark.parametrize("operation", ["add", "remove"])
+def test_config_mutation_rolls_back_on_save_failure(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    """Failed strict persistence restores the prior configured stack list."""
+    manager = port_monitor.PortMonitorStackManager()
+    manager._config_loaded = True
+    existing = port_monitor.PortMonitorStack("existing", "container", 80, [])
+    manager.stacks = [existing]
+    monkeypatch.setattr(manager, "check_port", lambda *_args: True)
+    monkeypatch.setattr(manager, "save_stacks", lambda: (_ for _ in ()).throw(YamlStoreError()))
+
+    def mutate() -> None:
+        if operation == "add":
+            manager.add_stack("new", "other", 81, [])
+        else:
+            manager.remove_stack("existing")
+
+    with pytest.raises(YamlStoreError):
+        mutate()
+    assert manager.stacks == [existing]
+
+
+def test_update_stack_restores_values_on_save_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The update endpoint leaves no unpersisted configuration in memory."""
+    stack = port_monitor.PortMonitorStack("x", "old", 80, ["secondary"], 60, "1.1.1.1")
+    monkeypatch.setattr(api_port_monitor.port_monitor_manager, "get_stack", lambda _name: stack)
+    monkeypatch.setattr(
+        api_port_monitor.port_monitor_manager,
+        "save_stacks",
+        lambda: (_ for _ in ()).throw(YamlStoreError()),
+    )
+    request = api_port_monitor.UpdatePortMonitorStackRequest(
+        primary_container="new",
+        primary_port=81,
+        secondary_containers=[],
+        interval=5,
+        public_ip="2.2.2.2",
+    )
+
+    with pytest.raises(YamlStoreError):
+        api_port_monitor.update_stack("x", request)
+    assert (stack.primary_container, stack.primary_port, stack.secondary_containers) == (
+        "old",
+        80,
+        ["secondary"],
+    )
+    assert (stack.interval, stack.public_ip) == (60, "1.1.1.1")

--- a/tests/test_proxy_config.py
+++ b/tests/test_proxy_config.py
@@ -1,0 +1,36 @@
+"""Tests for proxy configuration helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from backend import proxy_config
+from backend.yaml_store import YamlStoreError
+
+
+@pytest.fixture
+def temp_proxy_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point proxy helpers at a temporary proxies file.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory fixture.
+
+    Returns:
+        Temporary proxies YAML path.
+    """
+    path = tmp_path / "proxies.yaml"
+    monkeypatch.setattr(proxy_config, "PROXIES_PATH", str(path))
+    return path
+
+
+@pytest.mark.parametrize("content", ["null\n", "- not-a-mapping\n", "scalar\n"])
+def test_load_proxies_rejects_non_mapping_yaml(
+    temp_proxy_path: Path,
+    content: str,
+) -> None:
+    """Reject proxies YAML that violates the mapping contract."""
+    temp_proxy_path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(YamlStoreError):
+        proxy_config.load_proxies()

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -1,0 +1,109 @@
+"""Interface tests for YAML persistence."""
+
+from pathlib import Path
+import stat
+
+import pytest
+
+from backend.yaml_store import YamlStoreError, load_yaml_file, write_yaml_file
+
+
+def test_missing_file_returns_default(tmp_path: Path) -> None:
+    """Return the supplied default only for a missing primary file."""
+    default = {"enabled": True}
+    assert load_yaml_file(tmp_path / "missing.yaml", default) is default
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "  \n", "key: [unterminated\n"],
+)
+def test_invalid_content_raises(tmp_path: Path, content: str) -> None:
+    """Reject empty and malformed YAML instead of silently using defaults."""
+    path = tmp_path / "settings.yaml"
+    path.write_text(content, encoding="utf-8")
+    with pytest.raises(YamlStoreError):
+        load_yaml_file(path, {})
+
+
+def test_invalid_utf8_raises(tmp_path: Path) -> None:
+    """Report invalid UTF-8 through the public store exception."""
+    path = tmp_path / "settings.yaml"
+    path.write_bytes(b"\xff")
+    with pytest.raises(YamlStoreError):
+        load_yaml_file(path, {})
+
+
+def test_yaml_null_is_preserved_without_expected_type(tmp_path: Path) -> None:
+    """Preserve an explicit YAML null when no shape contract is requested."""
+    path = tmp_path / "settings.yaml"
+    path.write_text("null\n", encoding="utf-8")
+    assert load_yaml_file(path, {}) is None
+
+
+def test_wrong_top_level_type_raises(tmp_path: Path) -> None:
+    """Reject parsed data that violates the requested top-level type."""
+    path = tmp_path / "settings.yaml"
+    path.write_text("- value\n", encoding="utf-8")
+    with pytest.raises(YamlStoreError, match="expected dict"):
+        load_yaml_file(path, {}, expected_type=dict)
+
+
+def test_write_round_trips_and_creates_owner_only_file(tmp_path: Path) -> None:
+    """Create a new owner-only file whose YAML value round trips."""
+    path = tmp_path / "nested" / "settings.yaml"
+    data = {"label": "example", "enabled": True}
+    write_yaml_file(path, data)
+    assert load_yaml_file(path, {}, expected_type=dict) == data
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert not list(path.parent.glob(".yaml-*.tmp"))
+
+
+def test_write_rejects_direct_symlink(tmp_path: Path) -> None:
+    """Reject a direct symlink destination without changing its target."""
+    target = tmp_path / "target.yaml"
+    target.write_text("old: true\n", encoding="utf-8")
+    path = tmp_path / "settings.yaml"
+    path.symlink_to(target.name)
+
+    with pytest.raises(YamlStoreError, match="Refusing to replace symlink"):
+        write_yaml_file(path, {"new": True})
+    assert load_yaml_file(target, {}) == {"old": True}
+
+
+def test_write_cyclic_symlink_raises_store_error(tmp_path: Path) -> None:
+    """Report cyclic-link resolution through the public store exception."""
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.symlink_to(second.name)
+    second.symlink_to(first.name)
+
+    with pytest.raises(YamlStoreError, match="Refusing to replace symlink"):
+        write_yaml_file(first, {"new": True})
+
+
+def test_write_preserves_existing_mode(tmp_path: Path) -> None:
+    """Keep destination permissions across atomic replacement."""
+    path = tmp_path / "settings.yaml"
+    path.write_text("old: true\n", encoding="utf-8")
+    path.chmod(0o640)
+    write_yaml_file(path, {"new": True})
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+def test_failed_replace_keeps_destination_and_cleans_temp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Leave the old destination intact when atomic replacement fails."""
+    path = tmp_path / "settings.yaml"
+    path.write_text("old: true\n", encoding="utf-8")
+
+    def fail_replace(source: Path, destination: Path) -> None:
+        """Simulate an atomic replacement failure."""
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+    with pytest.raises(YamlStoreError, match="replace failed"):
+        write_yaml_file(path, {"new": True})
+    assert load_yaml_file(path, {}) == {"old": True}
+    assert not list(tmp_path.glob(".yaml-*.tmp"))

--- a/tests/workflows/__init__.py
+++ b/tests/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Backend workflow tests."""

--- a/tests/workflows/test_mam_status_workflow.py
+++ b/tests/workflows/test_mam_status_workflow.py
@@ -1,0 +1,62 @@
+"""Public MAM status workflow with deterministic network seams."""
+
+from typing import Any
+
+from httpx import AsyncClient
+import pytest
+
+from backend import app
+
+
+@pytest.mark.workflow
+async def test_forced_status_fetches_mam_account_and_persists_result(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetch MAM status through the public endpoint and persist the returned account state."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    session = {
+        "label": "seedbox",
+        "mam": {
+            "mam_id": "mam-cookie",
+            "session_type": "ip",
+            "ip_monitoring_mode": "static",
+        },
+        "mam_ip": "198.51.100.10",
+        "proxy": {},
+    }
+    assert (await api_client.post("/api/session/save", json=session)).is_success
+
+    async def ipinfo(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {"ip": "198.51.100.10", "asn": "AS64500"}
+
+    async def asn_lookup(*_args: Any, **_kwargs: Any) -> tuple[str, str]:
+        return "AS64500", "UTC"
+
+    async def mam_seen(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"ASN": 64500, "AS": "AS64500 TEST-NET"}
+
+    async def mam_status(mam_id: str, proxy_cfg: dict | None = None) -> dict[str, Any]:
+        assert mam_id == "mam-cookie"
+        assert proxy_cfg is None
+        return {
+            "mam_cookie_exists": True,
+            "points": 1234,
+            "wedge_active": False,
+            "vip_active": True,
+            "raw": {"uid": 7, "username": "reader"},
+        }
+
+    monkeypatch.setattr(app, "get_ipinfo_with_fallback", ipinfo)
+    monkeypatch.setattr(app, "get_asn_and_timezone_from_ip", asn_lookup)
+    monkeypatch.setattr(app, "get_mam_seen_ip_info", mam_seen)
+    monkeypatch.setattr(app, "get_status", mam_status)
+
+    response = await api_client.get("/api/status?label=seedbox&force=1")
+    assert response.status_code == 200
+    assert response.json()["mam_cookie_exists"] is True
+    assert response.json()["points"] == 1234
+    assert response.json()["details"]["raw"]["username"] == "reader"
+
+    persisted = (await api_client.get("/api/session/seedbox")).json()
+    assert persisted["last_status"]["points"] == 1234
+    assert persisted["last_status"]["raw"]["uid"] == 7

--- a/tests/workflows/test_port_monitor_workflow.py
+++ b/tests/workflows/test_port_monitor_workflow.py
@@ -1,0 +1,65 @@
+"""Public workflow coverage for port-monitor stack management."""
+
+from httpx import AsyncClient
+import pytest
+
+from backend.port_monitor import port_monitor_manager
+
+
+@pytest.mark.workflow
+async def test_port_monitor_create_edit_recheck_delete(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run the complete stack-management workflow through HTTP."""
+    monkeypatch.setattr(port_monitor_manager, "check_port", lambda _container, _port: True)
+    created = await api_client.post(
+        "/api/port-monitor/stacks",
+        json={
+            "name": "media",
+            "primary_container": "vpn",
+            "primary_port": 51413,
+            "secondary_containers": ["client"],
+            "interval": 5,
+        },
+    )
+    assert created.json() == {"success": True}
+    assert (await api_client.get("/api/port-monitor/stacks")).json()[0]["status"] == "OK"
+
+    updated = await api_client.put(
+        "/api/port-monitor/stacks?name=media",
+        json={
+            "primary_container": "vpn-new",
+            "primary_port": 51414,
+            "secondary_containers": ["client", "arr"],
+            "interval": 10,
+        },
+    )
+    assert updated.json() == {"success": True}
+    stack = (await api_client.get("/api/port-monitor/stacks")).json()[0]
+    assert (stack["primary_container"], stack["primary_port"], stack["interval"]) == (
+        "vpn-new",
+        51414,
+        10,
+    )
+    assert (await api_client.post("/api/port-monitor/stacks/recheck?name=media")).json() == {
+        "success": True
+    }
+    assert (await api_client.delete("/api/port-monitor/stacks?name=media")).json() == {
+        "success": True
+    }
+    assert (await api_client.get("/api/port-monitor/stacks")).json() == []
+
+    events = (await api_client.get("/api/ui_event_log")).json()
+    assert [event["event"] for event in events] == [
+        "port_monitor_created",
+        "port_monitor_edit",
+        "port_monitor_deleted",
+    ]
+
+
+@pytest.mark.workflow
+async def test_recheck_unknown_stack_returns_not_found(api_client: AsyncClient) -> None:
+    """Return an observable 404 for a missing stack."""
+    response = await api_client.post("/api/port-monitor/stacks/recheck?name=missing")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Stack not found"}


### PR DESCRIPTION
## Summary

Adds deterministic cross-layer coverage for MouseTrap’s backend APIs, browser workflows, and production container. The suite exercises real application boundaries with isolated configuration and local fake services, without requiring external credentials.

## What Changed

- Added backend pytest integration and workflow suites for sessions, proxies, notifications, port monitoring, MAM/indexer synchronization, persistence recovery, and service reload behavior.
- Added Playwright Chromium coverage for application startup, session and proxy workflows, notification configuration, event logs, validation, and backend failure feedback.
- Added a production-container smoke path covering the served React bundle, API availability, persisted sessions, reloads, and container restarts.
- Added a dedicated GitHub Actions workflow with separate backend, development E2E, and container-smoke jobs plus failure artifacts and logs.
- Added a unified `scripts/run-tests.sh` local gate and documented the required backend and frontend setup.
- Added stable semantic/test locators where needed and aligned persistence tests with the current atomic YAML recovery behavior.
- Includes the current upstream persistence and responsive-layout baseline needed by the rebased test branch.

## Why

The existing suite primarily covered backend behavior in isolation and did not verify complete user workflows across the React frontend, FastAPI backend, persisted configuration, and production image. These tests provide deterministic regression coverage at those public boundaries while keeping external services and credentials out of local and CI runs.